### PR TITLE
Add history support for proxy models

### DIFF
--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -29,5 +29,5 @@ def register(
         records.manager_name = manager_name
         records.module = app and ("%s.models" % app) or model.__module__
         records.add_extra_methods(model)
-        history_name = utils.natural_key_from_model(records.finalize(model))[1]
-        models.registered_models[natural_key] = history_name
+        records.concrete_natural_key = utils.natural_key_from_model(model._meta.concrete_model or model)
+        records.finalize(model)

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 __version__ = '1.5.4'
 
+from . import utils
+
 
 def register(
         model, app=None, manager_name='history', records_class=None,
@@ -19,12 +21,13 @@ def register(
     `HistoricalManager` instance directly to `model`.
     """
     from . import models
-    if model._meta.db_table not in models.registered_models:
+    natural_key = utils.natural_key_from_model(model)
+    if natural_key not in models.registered_models:
         if records_class is None:
             records_class = models.HistoricalRecords
         records = records_class(**records_config)
         records.manager_name = manager_name
         records.module = app and ("%s.models" % app) or model.__module__
         records.add_extra_methods(model)
-        records.finalize(model)
-        models.registered_models[model._meta.db_table] = model
+        history_name = utils.natural_key_from_model(records.finalize(model))[1]
+        models.registered_models[natural_key] = history_name

--- a/simple_history/management/commands/populate_history.py
+++ b/simple_history/management/commands/populate_history.py
@@ -39,7 +39,8 @@ class Command(BaseCommand):
                 to_process.add(model_pair)
 
         elif options['auto']:
-            for model in models.registered_models.values():
+            for app_label, model_name in models.registered_models:
+                model = get_model(app_label, model_name)
                 try:    # avoid issues with mutli-table inheritance
                     history_model = utils.get_history_model_for_model(model)
                 except utils.NotHistorical:

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -25,6 +25,7 @@ except ImportError:  # south not present
 else:  # south configuration for CustomForeignKeyField
     add_introspection_rules(
         [], ["^simple_history.models.CustomForeignKeyField"])
+from . import utils
 from .manager import HistoryDescriptor
 
 registered_models = {}
@@ -81,6 +82,7 @@ class HistoricalRecords(object):
         descriptor = HistoryDescriptor(history_model)
         setattr(sender, self.manager_name, descriptor)
         sender._meta.simple_history_manager_attribute = self.manager_name
+        return history_model
 
     def create_history_model(self, model):
         """
@@ -108,7 +110,7 @@ class HistoricalRecords(object):
         # type in python2 wants str as a first argument
         attrs.update(Meta=type(str('Meta'), (), self.get_meta_options(model)))
         name = 'Historical%s' % model._meta.object_name
-        registered_models[model._meta.db_table] = model
+        registered_models[utils.natural_key_from_model(model)] = name
         return python_2_unicode_compatible(
             type(str(name), self.bases, attrs))
 

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -117,6 +117,12 @@ class Paper(Document):
         self.changed_by = value
 
 
+class Record(Document):
+
+    class Meta:
+        proxy = True
+
+
 class Profile(User):
     date_of_birth = models.DateField()
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -22,7 +22,7 @@ from simple_history.models import HistoricalRecords, convert_auto_field
 from simple_history import register
 from ..models import (
     AdminProfile, Bookcase, MultiOneToOne, Poll, Choice, Voter, Restaurant,
-    Person, FileModel, Document, Book, HistoricalPoll, Library, State,
+    Person, FileModel, Document, Record, Book, HistoricalPoll, Library, State,
     AbstractBase, ConcreteAttr, ConcreteUtil, SelfFK, Temperature, WaterLevel,
     ExternalModel1, ExternalModel3, UnicodeVerboseName, HistoricalChoice,
     HistoricalState, HistoricalCustomFKError, Series, SeriesWork, PollInfo
@@ -288,6 +288,12 @@ class HistoricalRecordsTest(TestCase):
         poll.save()
         poll_info = PollInfo(poll=poll)
         poll_info.save()
+
+    def test_proxy_generates_history(self):
+        assert Record.history.count() == 0
+        Record.objects.create()
+        assert Record.history.count() == 1
+
 
 
 class RegisterTest(TestCase):

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -1,0 +1,9 @@
+"""Utility functions that don't depend on the rest of the app."""
+
+
+def natural_key_from_model(model):
+    opts = model._meta
+    try:
+        return opts.app_label, opts.model_name
+    except AttributeError:
+        return opts.app_label, opts.module_name


### PR DESCRIPTION
Somewhat based on https://github.com/emergence/django-simple-history/commit/9bb54005fd35ce75d887b232abb6fb44cbd13cb0.
- [ ] Test different proxy configurations (historical concrete with proxy, concrete with historical proxy, etc)
