### PR TITLE
Remove default accessor for historical models on auth.User

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ tip (unreleased)
 ----------------
 - Add support for Django 1.8+
 - Deprecated use of ``CustomForeignKeyField`` (to be removed)
+- Remove default reverse accessor to `auth.User` for historical models (gh-121)
 
 1.5.4 (2015-01-03)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -37,7 +37,7 @@ class HistoricalRecords(object):
     thread = threading.local()
 
     def __init__(self, verbose_name=None, bases=(models.Model,),
-                 user_related_name=None):
+                 user_related_name='+'):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
         try:

--- a/simple_history/tests/migration_test_app/migrations/0001_initial.py
+++ b/simple_history/tests/migration_test_app/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('history_id', models.AutoField(serialize=False, primary_key=True)),
                 ('history_date', models.DateTimeField()),
                 ('history_type', models.CharField(choices=[('+', 'Created'), ('~', 'Changed'), ('-', 'Deleted')], max_length=1)),
-                ('history_user', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
+                ('history_user', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL, null=True)),
             ],
             options={'ordering': ('-history_date', '-history_id'), 'get_latest_by': 'history_date', 'verbose_name': 'historical yar'},
             bases=(models.Model,),

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -237,3 +237,11 @@ class SeriesWork(models.Model):
 class PollInfo(models.Model):
     poll = models.ForeignKey(Poll, primary_key=True)
     history = HistoricalRecords()
+
+
+class UserAccessorDefault(models.Model):
+    pass
+
+
+class UserAccessorOverride(models.Model):
+    pass

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -17,7 +17,8 @@ from ..models import (
     Person, FileModel, Document, Book, HistoricalPoll, Library, State,
     AbstractBase, ConcreteAttr, ConcreteUtil, SelfFK, Temperature, WaterLevel,
     ExternalModel1, ExternalModel3, UnicodeVerboseName, HistoricalChoice,
-    HistoricalState, HistoricalCustomFKError, Series, SeriesWork, PollInfo
+    HistoricalState, HistoricalCustomFKError, Series, SeriesWork, PollInfo,
+    UserAccessorDefault, UserAccessorOverride
 )
 from ..external.models import ExternalModel2, ExternalModel4
 
@@ -694,3 +695,14 @@ class TestLatest(TestCase):
             {'pk': 2, 'history_date': yesterday},
         ])
         assert HistoricalPoll.objects.latest().pk == 1
+
+
+class TestUserAccessor(unittest.TestCase):
+
+    def test_accessor_default(self):
+        register(UserAccessorDefault)
+        assert not hasattr(User, 'historicaluseraccessordefault_set')
+
+    def test_accessor_override(self):
+        register(UserAccessorOverride, user_related_name='my_history_model_accessor')
+        assert hasattr(User, 'my_history_model_accessor')


### PR DESCRIPTION
Previously (#122) we added a workaround for clashing accessors on the User model. This change will prevent their creation by default. The workaround will still exist to allow creating the reverse relationship if desired.