### PR TITLE
Force OneToOne to be a ForeignKey on historical models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+tip (unreleased)
+----------------
+- Fix OneToOneField transformation for historical models (gh-166)
+
 1.6.0 (2015-04-16)
 ------------------
 - Add support for Django 1.8+


### PR DESCRIPTION
`OneToOneField` is really persistent about being unique. We need to treat them as `ForeignKeyField`.

Fixes #166 