### PR TITLE
Fix one-to-one relations in admin and restoring to historical instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 tip (unreleased)
 ----------------
 - Fix OneToOneField transformation for historical models (gh-166)
+- Disable cascading deletes from related models to historical models
+- Fix restoring historical instances with missing one-to-one relations (gh-162)
 
 1.6.0 (2015-04-16)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -147,6 +147,7 @@ class HistoricalRecords(object):
                     db_index=True,
                     serialize=True,
                     unique=False,
+                    on_delete=models.DO_NOTHING,
                     **field_arguments
                 )
                 field.name = old_field.name
@@ -173,7 +174,8 @@ class HistoricalRecords(object):
                     [getattr(self, opts.pk.attname), self.history_id])
 
         def get_instance(self):
-            return model(**dict([(k, getattr(self, k)) for k in fields]))
+            return model(**{field.attname: getattr(self, field.attname)
+                            for field in fields.values()})
 
         return {
             'history_id': models.AutoField(primary_key=True),

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -174,8 +174,8 @@ class HistoricalRecords(object):
                     [getattr(self, opts.pk.attname), self.history_id])
 
         def get_instance(self):
-            return model(**{field.attname: getattr(self, field.attname)
-                            for field in fields.values()})
+            return model(**dict([(field.attname, getattr(self, field.attname))
+                                for field in fields.values()]))
 
         return {
             'history_id': models.AutoField(primary_key=True),

--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.contrib import admin
 
 from simple_history.admin import SimpleHistoryAdmin
-from .models import Poll, Choice, Person, Book, Document, Paper
+from .models import Poll, Choice, Person, Book, Document, Paper, Employee
 
 
 class PersonAdmin(SimpleHistoryAdmin):
@@ -17,3 +17,4 @@ admin.site.register(Person, PersonAdmin)
 admin.site.register(Book, SimpleHistoryAdmin)
 admin.site.register(Document, SimpleHistoryAdmin)
 admin.site.register(Paper, SimpleHistoryAdmin)
+admin.site.register(Employee, SimpleHistoryAdmin)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -245,3 +245,8 @@ class UserAccessorDefault(models.Model):
 
 class UserAccessorOverride(models.Model):
     pass
+
+
+class Employee(models.Model):
+    manager = models.OneToOneField('Employee', null=True)
+    history = HistoricalRecords()

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -12,7 +12,7 @@ from django.contrib.admin.util import quote
 from django.conf import settings
 from simple_history.models import HistoricalRecords
 
-from ..models import Book, Person, Poll, State
+from ..models import Book, Person, Poll, State, Employee
 
 
 today = datetime(2021, 1, 1, 10, 0)
@@ -234,3 +234,14 @@ class AdminSiteTest(WebTest):
 
         historical_poll = poll.history.all()[0]
         self.assertEqual(historical_poll.history_user, None)
+
+    def test_missing_one_to_one(self):
+        """A relation to a missing one-to-one model should still show history"""
+        self.login()
+        manager = Employee.objects.create()
+        employee = Employee.objects.create(manager=manager)
+        employee.manager = None
+        employee.save()
+        manager.delete()
+        response = self.app.get(get_history_url(employee, 0))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
I was able to reproduce and fix what @ryangallen is talking about in #162. Once I can reproduce @bradford281's original error, I'll include that before this is merged.

Fixes #162 