### PR TITLE
[WIP] Generic Views Mixins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 dist/
+.eggs
 *.egg
 *.egg-info/
 build/
@@ -12,3 +13,5 @@ test_files/
 /.ve
 /.project
 /.pydevproject
+# Pycharm project
+.idea

--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,3 +1,3 @@
-max-line-length: 79
+max-line-length: 119
 uses:
   - django

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,8 @@ Authors
 - Daniel Levy
 - Daniel Roschka
 - David Hite
+- Edgar Gabaldi @edgabaldi
+- Fabio C. Barrionuevo da Luz @luzfcb
 - George Vilches
 - Hamish Downer
 - James Pulec

--- a/simple_history/forms.py
+++ b/simple_history/forms.py
@@ -1,0 +1,39 @@
+from __future__ import unicode_literals
+
+from django.utils import six
+
+__all__ = (
+    'ReadOnlyFieldsMixin',
+    'new_readonly_form'
+)
+
+
+class ReadOnlyFieldsMixin(object):
+    readonly_fields = ()
+    all_fields = False
+
+    def __init__(self, *args, **kwargs):
+        super(ReadOnlyFieldsMixin, self).__init__(*args, **kwargs)
+
+        for field in (field for field_name, field in six.iteritems(self.fields)
+                      if field_name in self.readonly_fields
+                      or self.all_fields is True):
+            field.widget.attrs['disabled'] = 'true'
+            field.required = False
+
+    def clean(self):
+        cleaned_data = super(ReadOnlyFieldsMixin, self).clean()
+        if self.all_fields:
+            for field_name, field in six.iteritems(self.fields):
+                cleaned_data[field_name] = getattr(self.instance, field_name)
+            return cleaned_data
+        else:
+            for field_name in self.readonly_fields:
+                cleaned_data[field_name] = getattr(self.instance, field_name)
+            return cleaned_data
+
+
+def new_readonly_form(klass, readonly_fields=()):
+    name = "ReadOnly{}".format(klass.__name__)
+    klass_fields = {'readonly_fields': readonly_fields}
+    return type(name, (ReadOnlyFieldsMixin, klass), klass_fields)

--- a/simple_history/forms.py
+++ b/simple_history/forms.py
@@ -34,7 +34,7 @@ class ReadOnlyFieldsMixin(object):
             return cleaned_data
 
 
-def new_readonly_form(klass, readonly_fields=()):
+def new_readonly_form(klass, all_fields=True, readonly_fields=()):
     name = force_str("ReadOnly{}".format(klass.__name__))
-    klass_fields = {'readonly_fields': readonly_fields}
+    klass_fields = {'all_fields': all_fields, 'readonly_fields': readonly_fields}
     return type(name, (ReadOnlyFieldsMixin, klass), klass_fields)

--- a/simple_history/forms.py
+++ b/simple_history/forms.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.utils import six
+from django.utils.encoding import force_str
 
 __all__ = (
     'ReadOnlyFieldsMixin',
@@ -34,6 +35,6 @@ class ReadOnlyFieldsMixin(object):
 
 
 def new_readonly_form(klass, readonly_fields=()):
-    name = "ReadOnly{}".format(klass.__name__)
+    name = force_str("ReadOnly{}".format(klass.__name__))
     klass_fields = {'readonly_fields': readonly_fields}
     return type(name, (ReadOnlyFieldsMixin, klass), klass_fields)

--- a/simple_history/forms.py
+++ b/simple_history/forms.py
@@ -5,36 +5,45 @@ from django.utils.encoding import force_str
 
 __all__ = (
     'ReadOnlyFieldsMixin',
-    'new_readonly_form'
+    'new_readonly_form_class'
 )
 
 
 class ReadOnlyFieldsMixin(object):
     readonly_fields = ()
-    all_fields = False
 
     def __init__(self, *args, **kwargs):
         super(ReadOnlyFieldsMixin, self).__init__(*args, **kwargs)
-
-        for field in (field for field_name, field in six.iteritems(self.fields)
-                      if field_name in self.readonly_fields
-                      or self.all_fields is True):
-            field.widget.attrs['disabled'] = 'true'
-            field.required = False
+        self.define_readonly_fields(self.fields)
 
     def clean(self):
         cleaned_data = super(ReadOnlyFieldsMixin, self).clean()
-        if self.all_fields:
-            for field_name, field in six.iteritems(self.fields):
+
+        for field_name, field in six.iteritems(self.fields):
+            if self._must_be_readonly(field_name):
                 cleaned_data[field_name] = getattr(self.instance, field_name)
-            return cleaned_data
-        else:
-            for field_name in self.readonly_fields:
-                cleaned_data[field_name] = getattr(self.instance, field_name)
-            return cleaned_data
+
+        return cleaned_data
+
+    def define_readonly_fields(self, field_list):
+
+        fields = [field for field_name, field in six.iteritems(field_list)
+                  if self._must_be_readonly(field_name)]
+
+        map(lambda field: self._set_readonly(field), fields)
+
+    def _all_fields(self):
+        return not bool(self.readonly_fields)
+
+    def _set_readonly(self, field):
+        field.widget.attrs['disabled'] = 'true'
+        field.required = False
+
+    def _must_be_readonly(self, field_name):
+        return field_name in self.readonly_fields or self._all_fields()
 
 
-def new_readonly_form(klass, all_fields=True, readonly_fields=()):
+def new_readonly_form_class(klass, readonly_fields=()):
     name = force_str("ReadOnly{}".format(klass.__name__))
-    klass_fields = {'all_fields': all_fields, 'readonly_fields': readonly_fields}
+    klass_fields = {'readonly_fields': readonly_fields}
     return type(name, (ReadOnlyFieldsMixin, klass), klass_fields)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -26,7 +26,7 @@ except ImportError:  # Django < 1.7
     from django.db.models.loading import get_app
     apps = None
 else:
-    get_app = apps.get_app
+    get_app = apps.get_app_config
 try:
     from south.modelsinspector import add_introspection_rules
 except ImportError:  # south not present

--- a/simple_history/tests/forms.py
+++ b/simple_history/tests/forms.py
@@ -1,0 +1,18 @@
+from django import forms
+
+from simple_history.forms import ReadOnlyFieldsMixin, new_readonly_form
+
+from .models import Poll
+
+
+class PollRevertForm(forms.ModelForm):
+    class Meta:
+        model = Poll
+        fields = '__all__'
+
+
+class ReadOnlyPollRevertForm(ReadOnlyFieldsMixin, PollRevertForm):
+    pass
+
+
+GeneratedByFunctionReadOnlyPollRevertForm = new_readonly_form(PollRevertForm, readonly_fields=())

--- a/simple_history/tests/forms.py
+++ b/simple_history/tests/forms.py
@@ -12,8 +12,7 @@ class PollRevertForm(forms.ModelForm):
 
 
 class ReadOnlyPollRevertForm(ReadOnlyFieldsMixin, PollRevertForm):
-    all_fields = True
-
+    pass
 
 
 GeneratedByFunctionReadOnlyPollRevertForm = new_readonly_form_class(PollRevertForm, readonly_fields=())

--- a/simple_history/tests/forms.py
+++ b/simple_history/tests/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from simple_history.forms import ReadOnlyFieldsMixin, new_readonly_form
+from simple_history.forms import ReadOnlyFieldsMixin, new_readonly_form_class
 
 from .models import Poll
 
@@ -16,4 +16,4 @@ class ReadOnlyPollRevertForm(ReadOnlyFieldsMixin, PollRevertForm):
 
 
 
-GeneratedByFunctionReadOnlyPollRevertForm = new_readonly_form(PollRevertForm, readonly_fields=())
+GeneratedByFunctionReadOnlyPollRevertForm = new_readonly_form_class(PollRevertForm, readonly_fields=())

--- a/simple_history/tests/forms.py
+++ b/simple_history/tests/forms.py
@@ -12,7 +12,8 @@ class PollRevertForm(forms.ModelForm):
 
 
 class ReadOnlyPollRevertForm(ReadOnlyFieldsMixin, PollRevertForm):
-    pass
+    all_fields = True
+
 
 
 GeneratedByFunctionReadOnlyPollRevertForm = new_readonly_form(PollRevertForm, readonly_fields=())

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -264,3 +264,9 @@ class Province(models.Model):
 class City(models.Model):
     country = models.ForeignKey(Country, db_column='countryCode')
     history = HistoricalRecords()
+
+
+class Dummy(models.Model):
+    foo = models.CharField(max_length=100)
+    bar = models.CharField(max_length=100)
+

--- a/simple_history/tests/tests/test_forms.py
+++ b/simple_history/tests/tests/test_forms.py
@@ -1,0 +1,65 @@
+from django.test import TestCase
+
+from django.forms import ModelForm
+import django
+from django.utils import six
+
+from ..models import Dummy
+from ..forms import ReadOnlyFieldsMixin
+
+
+class FooModelForm(ReadOnlyFieldsMixin, ModelForm):
+    class Meta:
+        model = Dummy
+        if django.VERSION >= (1, 6):
+            fields = '__all__'
+
+
+class BarModelForm(ReadOnlyFieldsMixin, ModelForm):
+    readonly_fields = ('foo',)
+
+    class Meta:
+        model = Dummy
+        if django.VERSION >= (1, 6):
+            fields = '__all__'
+
+
+class ReadOnlyFieldsMixinTestCase(TestCase):
+    def test_readonly_fields_attr_empty_all_fields_should_be_readonly(self):
+        form = FooModelForm()
+        self.assertEqual(['bar', 'foo'], self._get_readonly_fields(form))
+
+    def test_readonly_fields_just_defined_fields_should_be_readonly(self):
+        form = BarModelForm()
+        self.assertEqual(['foo', ], self._get_readonly_fields(form))
+
+    def test_clean_all_fields_readonly(self):
+        form = FooModelForm({'foo': 'FOO'})  # bar empty is invalid
+        form.is_valid()
+        self.assertEqual(['bar', 'foo'], self._get_fields_cleaned(form))
+
+    def test_clean_attr_empty_all_fields_0(self):
+        form = BarModelForm({'foo': 'FOO'})
+        form.is_valid()
+        self.assertEqual(['foo'], self._get_fields_cleaned(form))
+        self.assertTrue('bar' in form.errors.keys())
+
+    def test_clean_attr_empty_all_fields_1(self):
+        form = BarModelForm({'bar': 'BAR'})
+        form.is_valid()
+        self.assertEqual(['bar', 'foo'], self._get_fields_cleaned(form))
+
+    def _widget_attr_is_disabled(self, field):
+        return 'disabled' in field.widget.attrs and \
+               field.widget.attrs['disabled'] == 'true'
+
+    def _is_readonly(self, field):
+        return self._widget_attr_is_disabled(field) and not field.required
+
+    def _get_readonly_fields(self, form):
+        return sorted([field_name for field_name, field in six.iteritems(form.fields)
+                       if self._is_readonly(field)])
+
+    def _get_fields_cleaned(self, form):
+        return sorted([field_name for field_name, field in
+                       six.iteritems(form.cleaned_data)])

--- a/simple_history/tests/tests/test_views.py
+++ b/simple_history/tests/tests/test_views.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/simple_history/tests/urls.py
+++ b/simple_history/tests/urls.py
@@ -3,10 +3,40 @@ from __future__ import unicode_literals
 from django.conf.urls import include, url
 from django.contrib import admin
 from . import other_admin
+from . import views
 
 admin.autodiscover()
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^other-admin/', include(other_admin.site.urls)),
+
+    url(r'^poll-list/$', views.PollListView.as_view(), name='poll_list'),
+
+    url(r'^poll-history-versions-with-detail/(?P<pk>\d+)/$',
+        views.PollHistoryVersionsView.as_view(), name='poll_history_versions_with_detail'),
+
+    url(r'^poll-history-versions-with-update/(?P<pk>\d+)/$',
+        views.PollHistoryVersions2.as_view(), name='poll_history_versions_with_update'),
+
+    url(r'^poll-revert-view/(?P<pk>\d+)/$',
+        views.PollRevertView.as_view(), name='poll_revert_view'),
+
+    url(r'^pollrevertviewwithnormalform/(?P<pk>\d+)/$',
+        views.PollRevertViewWithNormalForm.as_view(), name='pollrevertviewwithnormalform'),
+
+    url(r'^pollrevertviewwithreadonlyform/(?P<pk>\d+)/$',
+        views.PollRevertViewWithReadOnlyForm.as_view(), name='pollrevertviewwithreadonlyform'),
+
+    url(r'^pollrevertviewwithgeneratedbyfunctionreadonlypollrevertform/(?P<pk>\d+)/$',
+        views.PollRevertViewWithGeneratedByFunctionReadOnlyPollRevertForm.as_view(),
+        name='pollrevertviewwithgeneratedbyfunctionreadonlypollrevertform'),
+
+    url(r'^place-list/$',
+        views.PlaceListView.as_view(), name='place_list'),
+
+    url(r'^placerevertviewwithmissinghistoryrecordsfieldexception/(?P<pk>\d+)/$',
+        views.PlaceRevertViewWithMissingHistoryRecordsFieldException.as_view(),
+        name='placerevertviewwithmissinghistoryrecordsfieldexception'),
+
 ]

--- a/simple_history/tests/views.py
+++ b/simple_history/tests/views.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals
+
+from django.core.urlresolvers import reverse_lazy
+from django.views import generic
+
+from simple_history.views import (HistoryRecordListViewMixin,
+                                  RevertFromHistoryRecordViewMixin)
+
+from .forms import (GeneratedByFunctionReadOnlyPollRevertForm, PollRevertForm,
+                    ReadOnlyPollRevertForm)
+from .models import Place, Poll
+
+
+class PollListView(generic.ListView):
+    model = Poll
+
+
+class PollHistoryVersionsView(HistoryRecordListViewMixin, generic.DetailView):
+    model = Poll
+
+
+class PollHistoryVersions2(HistoryRecordListViewMixin, generic.UpdateView):
+    model = Poll
+    success_url = reverse_lazy('poll_list')
+
+
+class PollRevertView(RevertFromHistoryRecordViewMixin, generic.UpdateView):
+    model = Poll
+    fields = '__all__'
+    success_url = reverse_lazy('poll_list')
+
+
+class PollRevertViewWithNormalForm(RevertFromHistoryRecordViewMixin, generic.UpdateView):
+    model = Poll
+    form_class = PollRevertForm
+    success_url = reverse_lazy('poll_list')
+
+
+class PollRevertViewWithReadOnlyForm(RevertFromHistoryRecordViewMixin, generic.UpdateView):
+    model = Poll
+    form_class = ReadOnlyPollRevertForm
+    success_url = reverse_lazy('poll_list')
+
+
+class PollRevertViewWithGeneratedByFunctionReadOnlyPollRevertForm(RevertFromHistoryRecordViewMixin,
+                                                                  generic.UpdateView):
+    model = Poll
+    form_class = GeneratedByFunctionReadOnlyPollRevertForm
+    success_url = reverse_lazy('poll_list')
+
+
+class PlaceListView(generic.ListView):
+    model = Place
+
+
+class PlaceRevertViewWithMissingHistoryRecordsFieldException(RevertFromHistoryRecordViewMixin,
+                                                             generic.UpdateView):
+    model = Place
+    fields = '__all__'
+    success_url = reverse_lazy('place_list')

--- a/simple_history/views.py
+++ b/simple_history/views.py
@@ -1,0 +1,300 @@
+from __future__ import unicode_literals
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.paginator import InvalidPage, Paginator
+from django.db.models import QuerySet
+from django.http import Http404
+from django.utils import six
+from django.utils.translation import ugettext as _
+
+from .forms import ReadOnlyFieldsMixin, new_readonly_form
+
+__all__ = (
+    'MissingHistoryRecordsField',
+    'HistoryRecordListViewMixin',
+    'RevertFromHistoryRecordViewMixin'
+)
+
+
+class MissingHistoryRecordsField(Exception):
+    """django-simple-history is somehow improperly configured"""
+    pass
+
+
+class HistoryRecordListViewMixin(object):
+    """
+    A mixin for views manipulating multiple django-simple-history HistoricalRecords of object.
+    """
+    history_records_allow_empty = True
+    history_records_queryset = None
+    history_records_paginate_by = None
+    history_records_paginate_orphans = 0
+    history_records_context_object_name = None
+    history_records_paginator_class = Paginator
+    history_records_page_kwarg = 'hpage'
+    history_records_ordering = None
+    history_records_object_list = None
+
+    def get_history_records_field_name(self):
+        """
+        Return the model HistoricalRecords field name to use get the history queryset.
+        """
+        if hasattr(self.model._meta, 'simple_history_manager_attribute'):
+            return self.model._meta.simple_history_manager_attribute
+        else:
+            raise MissingHistoryRecordsField(
+                "The model %(cls)s does not have a HistoryRecords field. Define a HistoryRecords()"
+                " field into %(cls)s model class, after do this, run:"
+                "\npython manage.py makemigrations %(app_label)s"
+                "\npython manage.py migrate %(app_label)s"
+                "\npython manage.py populate_history %(app_label)s.%(cls)s " % {
+                    'app_label': self.model._meta.app_label,
+                    'cls': self.model.__name__
+                }
+            )
+
+    def get_history_records_queryset(self):
+        """
+        Return the list of history_records items for this view.
+
+        The return value must be an iterable and may be an instance of
+        `QuerySet` in which case `QuerySet` specific behavior will be enabled.
+        """
+        if self.history_records_queryset is not None:
+            queryset = self.history_records_queryset
+            if isinstance(queryset, QuerySet):
+                queryset = queryset.all()
+        elif self.model is not None:
+            model_instance = self.get_object()
+            queryset = getattr(model_instance, self.get_history_records_field_name()).all()
+        else:
+            raise ImproperlyConfigured(
+                "%(cls)s is missing a HistoryRecords QuerySet. Define "
+                "%(cls)s.history_records_queryset, "
+                " or override %(cls)s.get_history_records_queryset()." % {
+                    'cls': self.__class__.__name__
+                }
+            )
+        ordering = self.get_history_records_ordering()
+        if ordering:
+            if isinstance(ordering, six.string_types):
+                ordering = (ordering,)
+            queryset = queryset.order_by(*ordering)
+
+        return queryset
+
+    def get_history_records_ordering(self):
+        """
+        Return the field or fields to use for ordering the history_records queryset.
+        """
+        return self.history_records_ordering
+
+    def paginate_history_records_queryset(self, queryset, page_size):
+        """
+        Paginate the history_records queryset, if needed.
+        """
+        paginator = self.get_history_records_paginator(
+            queryset, page_size, orphans=self.get_history_records_paginate_orphans(),
+            allow_empty_first_page=self.get_history_records_allow_empty())
+        page_kwarg = self.history_records_page_kwarg
+        page = self.kwargs.get(page_kwarg) or self.request.GET.get(page_kwarg) or 1
+        try:
+            page_number = int(page)
+        except ValueError:
+            if page == 'last':
+                page_number = paginator.num_pages
+            else:
+                raise Http404(
+                    _("HistoryRecords Page is not 'last', nor can it be converted to an int."))
+        try:
+            page = paginator.page(page_number)
+            return (paginator, page, page.object_list, page.has_other_pages())
+        except InvalidPage as e:
+            raise Http404(_('Invalid HistoryRecords page (%(page_number)s): %(message)s') % {
+                'page_number': page_number,
+                'message': str(e)
+            })
+
+    def get_history_records_paginate_by(self, queryset):
+        """
+        Get the number of history_records items to paginate by, or ``None`` for no pagination.
+        """
+        return self.history_records_paginate_by
+
+    def get_history_records_paginator(self, queryset, per_page, orphans=0,
+                                      allow_empty_first_page=True, **kwargs):
+        """
+        Return an instance of the history_records paginator for this view.
+        """
+        return self.history_records_paginator_class(
+            queryset, per_page, orphans=orphans,
+            allow_empty_first_page=allow_empty_first_page, **kwargs)
+
+    def get_history_records_paginate_orphans(self):
+        """
+        Returns the maximum number of orphans extend the last page by when
+        paginating.
+        """
+        return self.history_records_paginate_orphans
+
+    def get_history_records_allow_empty(self):
+        """
+        Returns ``True`` if the view should display empty history_records lists, and ``False``
+        if a 404 should be raised instead.
+        """
+        return self.history_records_allow_empty
+
+    def get_history_records_context_object_name(self):
+        """
+        Get the name of the history_records item to be used in the context.
+        """
+        if self.history_records_context_object_name:
+            return self.history_records_context_object_name
+        elif hasattr(self, 'model'):
+            return '%s_history_records_object_list' % self.model._meta.model_name
+        else:
+            return None
+
+    def get_context_data(self, **kwargs):
+        """
+        Get the context for this view.
+        """
+        history_records_queryset = kwargs.pop('history_records_object_list',
+                                              self.history_records_object_list)
+        history_records_page_size = self.get_history_records_paginate_by(history_records_queryset)
+        history_records_context_object_name = self.get_history_records_context_object_name()
+        if history_records_page_size:
+            (history_records_paginator, history_records_page, history_records_queryset,
+             history_records_is_paginated) = self.paginate_history_records_queryset(
+                history_records_queryset, history_records_page_size)
+            context = {
+                'history_records_paginator': history_records_paginator,
+                'history_records_page_obj': history_records_page,
+                'history_records_is_paginated': history_records_is_paginated,
+                'history_records_page_kwarg': self.history_records_page_kwarg,
+                'history_records_object_list': history_records_queryset
+            }
+        else:
+            context = {
+                'history_records_paginator': None,
+                'history_records_page_obj': None,
+                'history_records_is_paginated': False,
+                'history_records_page_kwarg': self.history_records_page_kwarg,
+                'history_records_object_list': history_records_queryset
+            }
+        if history_records_context_object_name is not None:
+            context[history_records_context_object_name] = history_records_queryset
+        context.update(kwargs)
+        return super(HistoryRecordListViewMixin, self).get_context_data(**context)
+
+    def get(self, request, *args, **kwargs):
+        self.history_records_object_list = self.get_history_records_queryset()
+        history_records_allow_empty = self.get_history_records_allow_empty()
+
+        if not history_records_allow_empty:
+            # When pagination is enabled and history_records_object_list is a queryset,
+            # it's better to do a cheap query than to load the unpaginated
+            # queryset in memory.
+            if (self.get_history_records_paginate_by(
+                self.history_records_object_list) is not None and hasattr(
+                self.history_records_object_list, 'exists')):  # noqa
+                is_empty = not self.history_records_object_list.exists()
+            else:
+                is_empty = len(self.history_records_object_list) == 0
+            if is_empty:
+                raise Http404(
+                    _("Empty HistoryRecords list and "
+                      "'%(class_name)s.history_records_allow_empty' is False.")
+                    % {'class_name': self.__class__.__name__})
+
+        return super(HistoryRecordListViewMixin, self).get(self, request, *args, **kwargs)
+
+
+class RevertFromHistoryRecordViewMixin(object):
+    history_records_readonly_form = True
+
+    def get_form_class(self):
+        form_klass = super(RevertFromHistoryRecordViewMixin, self).get_form_class()
+        if issubclass(form_klass, ReadOnlyFieldsMixin):
+            return form_klass
+        else:
+            return new_readonly_form(form_klass,
+                                     all_fields=self.history_records_readonly_form,
+                                     readonly_fields=()
+                                     )
+
+    def get_history_records_field_name(self):
+        """
+        Return the model HistoricalRecords field name to use get the history queryset.
+        """
+        if hasattr(self.model._meta, 'simple_history_manager_attribute'):
+            return self.model._meta.simple_history_manager_attribute
+        else:
+            raise MissingHistoryRecordsField(
+                "The model %(cls)s does not have a HistoryRecords field. Define a HistoryRecords()"
+                " field into %(cls)s model class, after do this, run:"
+                "\npython manage.py makemigrations %(app_label)s"
+                "\npython manage.py migrate %(app_label)s"
+                "\npython manage.py populate_history %(app_label)s.%(cls)s " % {
+                    'app_label': self.model._meta.app_label,
+                    'cls': self.model.__name__
+                }
+            )
+
+    def get_object(self, queryset=None):
+        """
+        Returns the object the view is displaying.
+
+        By default this requires `self.queryset` and a `pk` or `slug` argument
+        in the URLconf, but subclasses can override this to return any object.
+        """
+        # Use a custom queryset if provided; this is required for subclasses
+        # like DateDetailView
+        if queryset is None:
+            queryset = self.get_queryset()
+
+        # Next, try looking up by primary key.
+        pk = self.kwargs.get(self.pk_url_kwarg, None)
+        slug = self.kwargs.get(self.slug_url_kwarg, None)
+        if pk is not None:
+            queryset = queryset.filter(history_id=pk)
+
+        # Next, try looking up by slug.
+        if slug is not None and (pk is None or self.query_pk_and_slug):
+            slug_field = self.get_slug_field()
+            queryset = queryset.filter(**{slug_field: slug})
+
+        # If none of those are defined, it's an error.
+        if pk is None and slug is None:
+            raise AttributeError("Generic detail view %s must be called with "
+                                 "either an object pk or a slug."
+                                 % self.__class__.__name__)
+
+        try:
+            # Get the single item from the filtered queryset
+            obj = queryset.get()
+        except queryset.model.DoesNotExist:
+            raise Http404(_("No %(verbose_name)s found matching the query") %
+                          {'verbose_name': queryset.model._meta.verbose_name})
+        return obj.instance
+
+    def get_queryset(self):
+        """
+        Return the `QuerySet` that will be used to look up the history records of object.
+
+        Note that this method is called by the default implementation of
+        `get_object` and may not be called if `get_object` is overridden.
+        """
+        if self.queryset is None:
+            if self.model:
+                queryset = getattr(self.model, self.get_history_records_field_name()).all()
+                return queryset
+            else:
+                raise ImproperlyConfigured(
+                    "%(cls)s is missing a QuerySet. Define "
+                    "%(cls)s.model, %(cls)s.queryset, or override "
+                    "%(cls)s.get_queryset()." % {
+                        'cls': self.__class__.__name__
+                    }
+                )
+        return self.queryset.all()

--- a/simple_history/views.py
+++ b/simple_history/views.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import InvalidPage, Paginator
-from django.db.models import QuerySet
+from django.db.models.query import QuerySet
 from django.http import Http404
 from django.utils import six
 from django.utils.translation import ugettext as _

--- a/simple_history/views.py
+++ b/simple_history/views.py
@@ -7,7 +7,7 @@ from django.http import Http404
 from django.utils import six
 from django.utils.translation import ugettext as _
 
-from .forms import ReadOnlyFieldsMixin, new_readonly_form
+from .forms import ReadOnlyFieldsMixin, new_readonly_form_class
 
 __all__ = (
     'MissingHistoryRecordsField',
@@ -215,13 +215,12 @@ class RevertFromHistoryRecordViewMixin(object):
 
     def get_form_class(self):
         form_klass = super(RevertFromHistoryRecordViewMixin, self).get_form_class()
-        if issubclass(form_klass, ReadOnlyFieldsMixin):
+        if not self.history_records_readonly_form or issubclass(form_klass, ReadOnlyFieldsMixin):
             return form_klass
         else:
-            return new_readonly_form(form_klass,
-                                     all_fields=self.history_records_readonly_form,
-                                     readonly_fields=()
-                                     )
+            return new_readonly_form_class(form_klass,
+                                           readonly_fields=()
+                                           )
 
     def get_history_records_field_name(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist =
 ignore = N802
 max-complexity = 10
 exclude = __init__.py
+max-line-length = 119
 
 
 [testenv:flake8]


### PR DESCRIPTION
It is not ready because it has no tests (sorry, I still do not know how to write tests in this time).

The idea is out of the django admin:

1 . Providing a simple way to get the historical changes of model instance in the template context with pagination (for use with DetailView, UpdateView or any view that implements the get_object() method)
2 . Providing a simple way revert model instance to a chosen version in history, for use with UpdateView (all fields of the form will be read-only) causing the revert is made in full and without modification

TODO: 
- [ ] I still would like to include an additional optional check to the revert view. Include a password field for the currently logged in User, enter your own password again to validate the revert and to avoid mistakes.
- [x] I would like to eliminate the field `all_fields`from `ReadOnlyFieldsMixin`. - fixed in https://github.com/luzfcb/django-simple-history/commit/b76dd3c1736b5233f95453ea7cd9e3252aea2750 . 
- [ ] RestoreDeletedView
- [ ] Permissions !?
- [ ] Write tests
- [ ] Write docs

any feedback is welcome.

sorry my ugly English. English is not my native language. I still have a lot to learn.
