### PR TITLE
Add ability to edit history

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import simple_history
 
 tests_require = [
-    "Django>=1.4", "webtest==2.0.6", "django-webtest==1.7", "mock==1.2.0"
+    "Django>=1.4", "webtest==2.0.6", "django-webtest==1.7", "mock==1.0.1"
 ]
 try:
     from unittest import skipUnless

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from setuptools import setup
 import simple_history
 
-tests_require = ["Django>=1.4", "webtest==2.0.6", "django-webtest==1.7"]
+tests_require = [
+    "Django>=1.4", "webtest==2.0.6", "django-webtest==1.7", "mock==1.2.0"
+]
 try:
     from unittest import skipUnless
 except ImportError:  # Python 2.6 compatibility

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import PermissionDenied
 from django.conf.urls import patterns, url
 from django.contrib import admin
-from django.contrib.admin import helpers
+from django.contrib.admin import helpers, ModelAdmin
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
@@ -26,7 +26,7 @@ except AttributeError:  # Django < 1.5
 USER_NATURAL_KEY = tuple(key.lower() for key in USER_NATURAL_KEY.split('.', 1))
 
 
-class SimpleHistoryAdmin(admin.ModelAdmin):
+class SimpleHistoryAdmin(ModelAdmin):
     object_history_template = "simple_history/object_history.html"
     object_history_form_template = "simple_history/object_history_form.html"
 

--- a/simple_history/templates/simple_history/object_history_form.html
+++ b/simple_history/templates/simple_history/object_history_form.html
@@ -13,13 +13,10 @@
   </div>
 {% endblock %}
 
-{% comment %}Hack to remove "Save as New" and "Save and Continue" buttons {% endcomment %}
-{% block content %}
-  {% with 1 as is_popup %}
-    {{block.super}}
-  {% endwith %}
+{% block submit_buttons_bottom %}
+  {% include "simple_history/submit_line.html" %}
 {% endblock %}
 
 {% block form_top %}
-  <p>{% blocktrans %}Press the save button below to revert to this version of the object.{% endblocktrans %}</p>
+  <p>{% blocktrans %}Press the 'Revert' button below to revert to this version of the object. Or press the 'Change History' button to edit the history.{% endblocktrans %}</p>
 {% endblock %}

--- a/simple_history/templates/simple_history/object_history_form.html
+++ b/simple_history/templates/simple_history/object_history_form.html
@@ -18,5 +18,5 @@
 {% endblock %}
 
 {% block form_top %}
-  <p>{% blocktrans %}Press the 'Revert' button below to revert to this version of the object. Or press the 'Change History' button to edit the history.{% endblocktrans %}</p>
+<p>{% blocktrans %}Press the 'Revert' button below to revert to this version of the object.{% endblocktrans %} {% if change_history %}{% blocktrans %}Or press the 'Change History' button to edit the history.{% endblocktrans %}{% endif %}</p>
 {% endblock %}

--- a/simple_history/templates/simple_history/submit_line.html
+++ b/simple_history/templates/simple_history/submit_line.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+<div class="submit-row">
+<input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
+<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>
+</div>

--- a/simple_history/templates/simple_history/submit_line.html
+++ b/simple_history/templates/simple_history/submit_line.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 <div class="submit-row">
 <input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
-<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>
+{% if change_history %}<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>{% endif %}
 </div>

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -248,7 +248,9 @@ class AdminSiteTest(WebTest):
         self.assertEqual(historical_poll.history_user, None)
 
     def test_missing_one_to_one(self):
-        """A relation to a missing one-to-one model should still show history"""
+        """
+        A relation to a missing one-to-one model should still show history
+        """
         self.login()
         manager = Employee.objects.create()
         employee = Employee.objects.create(manager=manager)
@@ -259,6 +261,10 @@ class AdminSiteTest(WebTest):
         self.assertEqual(response.status_code, 200)
 
     def test_response_change(self):
+        """
+        Test the response_change method that it works with a _change_history
+        in the POST and settings.SIMPLE_HISTORY_EDIT set to True
+        """
         request = RequestFactory().post('/')
         request.POST = {'_change_history': True}
         request.session = 'session'
@@ -269,11 +275,41 @@ class AdminSiteTest(WebTest):
         poll.question = "how?"
         poll.save()
 
-        admin = SimpleHistoryAdmin(Poll, 'admin')
+        admin_site = AdminSite()
+        admin = SimpleHistoryAdmin(Poll, admin_site)
+
+        with override_settings(SIMPLE_HISTORY_EDIT=True):
+            response = admin.response_change(request, poll)
+
+        self.assertEqual(response.url, '/awesome/url/')
+
+    def test_response_change_change_history_setting_off(self):
+        """
+        Test the response_change method that it works with a _change_history
+        in the POST and settings.SIMPLE_HISTORY_EDIT set to False
+        """
+        request = RequestFactory().post('/')
+        request.POST = {'_change_history': True}
+        request.session = 'session'
+        request._messages = FallbackStorage(request)
+        request.path = '/awesome/url/'
+        request.user = self.user
+
+        poll = Poll.objects.create(question="why?", pub_date=today)
+        poll.question = "how?"
+        poll.save()
+
+        admin_site = AdminSite()
+        admin = SimpleHistoryAdmin(Poll, admin_site)
 
         response = admin.response_change(request, poll)
 
-        self.assertEqual(response.url, '/awesome/url/')
+        with patch(
+                'simple_history.admin.ModelAdmin.response_change') as m_admin:
+            m_admin.return_value = 'it was called'
+            response = admin.response_change(request, poll)
+
+        self.assertEqual(response, 'it was called')
 
     def test_response_change_no_change_history(self):
         request = RequestFactory().post('/')
@@ -285,11 +321,12 @@ class AdminSiteTest(WebTest):
         poll.question = "how?"
         poll.save()
 
-        admin = SimpleHistoryAdmin(Poll, 'admin')
+        admin_site = AdminSite()
+        admin = SimpleHistoryAdmin(Poll, admin_site)
 
         with patch(
-            'simple_history.admin.ModelAdmin.response_change') as mock_admin:
-            mock_admin.return_value = 'it was called'
+                'simple_history.admin.ModelAdmin.response_change') as m_admin:
+            m_admin.return_value = 'it was called'
             response = admin.response_change(request, poll)
 
         self.assertEqual(response, 'it was called')
@@ -305,7 +342,6 @@ class AdminSiteTest(WebTest):
         poll.save()
         history = poll.history.all()[0]
 
-
         admin_site = AdminSite()
         admin = SimpleHistoryAdmin(Poll, admin_site)
 
@@ -315,8 +351,9 @@ class AdminSiteTest(WebTest):
         context = {
             # Verify this is set for original object
             'original': poll,
+            'change_history': False,
 
-            'title': 'Revert {}'.format(force_text(history)),
+            'title': 'Revert {}'.format(force_text(poll)),
             'adminform': ANY,
             'object_id': poll.id,
             'is_popup': False,
@@ -363,16 +400,17 @@ class AdminSiteTest(WebTest):
         poll.save()
         history = poll.history.all()[0]
 
-
         admin_site = AdminSite()
         admin = SimpleHistoryAdmin(Poll, admin_site)
 
         with patch('simple_history.admin.render') as mock_render:
-            admin.history_form_view(request, poll.id, history.pk)
+            with override_settings(SIMPLE_HISTORY_EDIT=True):
+                admin.history_form_view(request, poll.id, history.pk)
 
         context = {
             # Verify this is set for history object not poll object
             'original': history,
+            'change_history': True,
 
             'title': 'Revert {}'.format(force_text(history)),
             'adminform': ANY,
@@ -388,6 +426,65 @@ class AdminSiteTest(WebTest):
             'changelist_url': '/admin/tests/poll/',
             'change_url': '/admin/tests/poll/2/',
             'history_url': '/admin/tests/poll/2/history/',
+            'add': False,
+            'change': True,
+            'has_add_permission': admin.has_add_permission(request),
+            'has_change_permission': admin.has_change_permission(
+                request, poll),
+            'has_delete_permission': admin.has_delete_permission(
+                request, poll),
+            'has_file_field': True,
+            'has_absolute_url': False,
+            'form_url': '',
+            'opts': ANY,
+            'content_type_id': ANY,
+            'save_as': admin.save_as,
+            'save_on_top': admin.save_on_top,
+            'root_path': getattr(admin_site, 'root_path', None),
+        }
+
+        mock_render.assert_called_once_with(
+            request, template_name=admin.object_history_form_template,
+            dictionary=context, current_app=admin_site.name)
+
+    def test_history_form_view_getting_history_with_setting_off(self):
+        request = RequestFactory().post('/')
+        request.session = 'session'
+        request._messages = FallbackStorage(request)
+        request.user = self.user
+        request.POST = {'_change_history': True}
+
+        poll = Poll.objects.create(question="why?", pub_date=today)
+        poll.question = "how?"
+        poll.save()
+        history = poll.history.all()[0]
+
+        admin_site = AdminSite()
+        admin = SimpleHistoryAdmin(Poll, admin_site)
+
+        with patch('simple_history.admin.render') as mock_render:
+            with override_settings(SIMPLE_HISTORY_EDIT=False):
+                admin.history_form_view(request, poll.id, history.pk)
+
+        context = {
+            # Verify this is set for history object not poll object
+            'original': poll,
+            'change_history': False,
+
+            'title': 'Revert {}'.format(force_text(poll)),
+            'adminform': ANY,
+            'object_id': poll.id,
+            'is_popup': False,
+            'media': ANY,
+            'errors': [
+                '<ul class="errorlist"><li>This field is required.</li></ul>',
+                '<ul class="errorlist"><li>This field is required.</li></ul>'
+            ],
+            'app_label': 'tests',
+            'original_opts': ANY,
+            'changelist_url': '/admin/tests/poll/',
+            'change_url': '/admin/tests/poll/1/',
+            'history_url': '/admin/tests/poll/1/history/',
             'add': False,
             'change': True,
             'has_add_permission': admin.has_add_permission(request),

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -1,10 +1,16 @@
 from datetime import datetime, timedelta
 
+from mock import patch, MagicMock, PropertyMock, ANY
 from django_webtest import WebTest
+from django.contrib.admin import AdminSite
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test.utils import override_settings
+from django.test.client import RequestFactory
 from django import VERSION
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.utils.encoding import force_text
 
 try:
     from django.contrib.auth import get_user_model
@@ -17,6 +23,7 @@ except ImportError:  # Django < 1.7
     from django.contrib.admin.util import quote
 
 from simple_history.models import HistoricalRecords
+from simple_history.admin import SimpleHistoryAdmin
 from ..models import Book, Person, Poll, State, Employee
 
 
@@ -250,3 +257,154 @@ class AdminSiteTest(WebTest):
         manager.delete()
         response = self.app.get(get_history_url(employee, 0))
         self.assertEqual(response.status_code, 200)
+
+    def test_response_change(self):
+        request = RequestFactory().post('/')
+        request.POST = {'_change_history': True}
+        request.session = 'session'
+        request._messages = FallbackStorage(request)
+        request.path = '/awesome/url/'
+
+        poll = Poll.objects.create(question="why?", pub_date=today)
+        poll.question = "how?"
+        poll.save()
+
+        admin = SimpleHistoryAdmin(Poll, 'admin')
+
+        response = admin.response_change(request, poll)
+
+        self.assertEqual(response.url, '/awesome/url/')
+
+    def test_response_change_no_change_history(self):
+        request = RequestFactory().post('/')
+        request.session = 'session'
+        request._messages = FallbackStorage(request)
+        request.user = self.user
+
+        poll = Poll.objects.create(question="why?", pub_date=today)
+        poll.question = "how?"
+        poll.save()
+
+        admin = SimpleHistoryAdmin(Poll, 'admin')
+
+        with patch(
+            'simple_history.admin.ModelAdmin.response_change') as mock_admin:
+            mock_admin.return_value = 'it was called'
+            response = admin.response_change(request, poll)
+
+        self.assertEqual(response, 'it was called')
+
+    def test_history_form_view_without_getting_history(self):
+        request = RequestFactory().post('/')
+        request.session = 'session'
+        request._messages = FallbackStorage(request)
+        request.user = self.user
+
+        poll = Poll.objects.create(question="why?", pub_date=today)
+        poll.question = "how?"
+        poll.save()
+        history = poll.history.all()[0]
+
+
+        admin_site = AdminSite()
+        admin = SimpleHistoryAdmin(Poll, admin_site)
+
+        with patch('simple_history.admin.render') as mock_render:
+            admin.history_form_view(request, poll.id, history.pk)
+
+        context = {
+            # Verify this is set for original object
+            'original': poll,
+
+            'title': 'Revert {}'.format(force_text(history)),
+            'adminform': ANY,
+            'object_id': poll.id,
+            'is_popup': False,
+            'media': ANY,
+            'errors': [
+                '<ul class="errorlist"><li>This field is required.</li></ul>',
+                '<ul class="errorlist"><li>This field is required.</li></ul>'
+            ],
+            'app_label': 'tests',
+            'original_opts': ANY,
+            'changelist_url': '/admin/tests/poll/',
+            'change_url': '/admin/tests/poll/1/',
+            'history_url': '/admin/tests/poll/1/history/',
+            'add': False,
+            'change': True,
+            'has_add_permission': admin.has_add_permission(request),
+            'has_change_permission': admin.has_change_permission(
+                request, poll),
+            'has_delete_permission': admin.has_delete_permission(
+                request, poll),
+            'has_file_field': True,
+            'has_absolute_url': False,
+            'form_url': '',
+            'opts': ANY,
+            'content_type_id': ANY,
+            'save_as': admin.save_as,
+            'save_on_top': admin.save_on_top,
+            'root_path': getattr(admin_site, 'root_path', None),
+        }
+
+        mock_render.assert_called_once_with(
+            request, template_name=admin.object_history_form_template,
+            dictionary=context, current_app=admin_site.name)
+
+    def test_history_form_view_getting_history(self):
+        request = RequestFactory().post('/')
+        request.session = 'session'
+        request._messages = FallbackStorage(request)
+        request.user = self.user
+        request.POST = {'_change_history': True}
+
+        poll = Poll.objects.create(question="why?", pub_date=today)
+        poll.question = "how?"
+        poll.save()
+        history = poll.history.all()[0]
+
+
+        admin_site = AdminSite()
+        admin = SimpleHistoryAdmin(Poll, admin_site)
+
+        with patch('simple_history.admin.render') as mock_render:
+            admin.history_form_view(request, poll.id, history.pk)
+
+        context = {
+            # Verify this is set for history object not poll object
+            'original': history,
+
+            'title': 'Revert {}'.format(force_text(history)),
+            'adminform': ANY,
+            'object_id': poll.id,
+            'is_popup': False,
+            'media': ANY,
+            'errors': [
+                '<ul class="errorlist"><li>This field is required.</li></ul>',
+                '<ul class="errorlist"><li>This field is required.</li></ul>'
+            ],
+            'app_label': 'tests',
+            'original_opts': ANY,
+            'changelist_url': '/admin/tests/poll/',
+            'change_url': '/admin/tests/poll/2/',
+            'history_url': '/admin/tests/poll/2/history/',
+            'add': False,
+            'change': True,
+            'has_add_permission': admin.has_add_permission(request),
+            'has_change_permission': admin.has_change_permission(
+                request, poll),
+            'has_delete_permission': admin.has_delete_permission(
+                request, poll),
+            'has_file_field': True,
+            'has_absolute_url': False,
+            'form_url': '',
+            'opts': ANY,
+            'content_type_id': ANY,
+            'save_as': admin.save_as,
+            'save_on_top': admin.save_on_top,
+            'root_path': getattr(admin_site, 'root_path', None),
+        }
+
+        mock_render.assert_called_once_with(
+            request, template_name=admin.object_history_form_template,
+            dictionary=context, current_app=admin_site.name)

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -353,15 +353,12 @@ class AdminSiteTest(WebTest):
             'original': poll,
             'change_history': False,
 
-            'title': 'Revert {}'.format(force_text(poll)),
+            'title': 'Revert %s' % force_text(poll),
             'adminform': ANY,
             'object_id': poll.id,
             'is_popup': False,
             'media': ANY,
-            'errors': [
-                '<ul class="errorlist"><li>This field is required.</li></ul>',
-                '<ul class="errorlist"><li>This field is required.</li></ul>'
-            ],
+            'errors': ANY,
             'app_label': 'tests',
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',
@@ -412,15 +409,12 @@ class AdminSiteTest(WebTest):
             'original': history,
             'change_history': True,
 
-            'title': 'Revert {}'.format(force_text(history)),
+            'title': 'Revert %s' % force_text(history),
             'adminform': ANY,
             'object_id': poll.id,
             'is_popup': False,
             'media': ANY,
-            'errors': [
-                '<ul class="errorlist"><li>This field is required.</li></ul>',
-                '<ul class="errorlist"><li>This field is required.</li></ul>'
-            ],
+            'errors': ANY,
             'app_label': 'tests',
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',
@@ -471,15 +465,12 @@ class AdminSiteTest(WebTest):
             'original': poll,
             'change_history': False,
 
-            'title': 'Revert {}'.format(force_text(poll)),
+            'title': 'Revert %s' % force_text(poll),
             'adminform': ANY,
             'object_id': poll.id,
             'is_popup': False,
             'media': ANY,
-            'errors': [
-                '<ul class="errorlist"><li>This field is required.</li></ul>',
-                '<ul class="errorlist"><li>This field is required.</li></ul>'
-            ],
+            'errors': ANY,
             'app_label': 'tests',
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -281,7 +281,7 @@ class AdminSiteTest(WebTest):
         with override_settings(SIMPLE_HISTORY_EDIT=True):
             response = admin.response_change(request, poll)
 
-        self.assertEqual(response.url, '/awesome/url/')
+        self.assertEqual(response['Location'], '/awesome/url/')
 
     def test_response_change_change_history_setting_off(self):
         """


### PR DESCRIPTION
We have found a need where we need the ability to have a history for a model, but we also need the ability to edit it as well. This adds in the ability to edit the history if necessary, but it can be turned on and off with a setting. By default it is off.

I still need to add docs, but just wanted to get this up.

Also I added unit tests for the feature as well. Was having trouble doing the integration tests to test this feature so opted for the unit tests.