### PR TITLE
Add history listing of deleted objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 python:
   - 2.6
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   - DJANGO="Django>=1.8,<1.9"
 
 install:
-  - pip install -U coverage codecov $DJANGO
+  - pip install -U 'coverage<4' codecov $DJANGO
   - python -c 'from __future__ import print_function; import django; print("Django " + django.get_version())'
 
 script: coverage run setup.py test

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+tip (unreleased)
+----------------
+- Add ability to list history in admin when the object instance is deleted. (gh-72)
+
 1.6.3 (2015-07-30)
 ------------------
 - Respect `to_field` and `db_column` parameters (gh-182)

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -250,3 +250,13 @@ class AdminSiteTest(WebTest):
         manager.delete()
         response = self.app.get(get_history_url(employee, 0))
         self.assertEqual(response.status_code, 200)
+
+    def test_history_deleted_instance(self):
+        """Ensure history page can be retrieved even for deleted instances"""
+        self.login()
+        employee = Employee.objects.create()
+        employee_pk = employee.pk
+        employee.delete()
+        employee.pk = employee_pk
+        response = self.app.get(get_history_url(employee))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
It has been a really long time since I looked at this, and it turned out easier than I thought. Of course, the main admin page for the object will still give you a 404, but if you navigate directly to the history page you'll be able to view the list of changes after an object has been deleted.

resolves #72