### PR TITLE
Support for custom tables names

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ Authors
 - Joao Pedro Francese
 - jofusa
 - John Whitlock
+- Jonathan Leroy
 - Jonathan Sanchez
 - Josh Fyne
 - Klaas van Schelven

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 tip (unreleased)
 ----------------
 - Add ability to list history in admin when the object instance is deleted. (gh-72)
+- Support for custom tables names (gh-196)
 
 1.6.3 (2015-07-30)
 ------------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -158,3 +158,29 @@ To change the auto-generated HistoricalRecord models base class from
         pub_date = models.DateTimeField('date published')
         changed_by = models.ForeignKey('auth.User')
         history = HistoricalRecords(bases=[RoutableModel])
+
+Custom history table name
+-------------------------
+
+By default, the table name for historical models follow the Django convention
+and just add ``historical`` before model name. For instance, if your application
+name is ``polls`` and your model name ``Question``, then the table name will be
+``polls_historicalquestion``.
+
+You can use the ``table_name`` parameter with both ``HistoricalRecords()`` or
+``register()`` to change this behavior.
+
+.. code-block:: python
+
+    class Question(models.Model):
+        question_text = models.CharField(max_length=200)
+        pub_date = models.DateTimeField('date published')
+        history = HistoricalRecords(table_name='polls_question_history')
+
+.. code-block:: python
+
+    class Question(models.Model):
+        question_text = models.CharField(max_length=200)
+        pub_date = models.DateTimeField('date published')
+
+    register(Question, table_name='polls_question_history')

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -5,7 +5,7 @@ __version__ = '1.6.3'
 
 def register(
         model, app=None, manager_name='history', records_class=None,
-        **records_config):
+        table_name=None, **records_config):
     """
     Create historical model for `model` and attach history manager to `model`.
 
@@ -14,6 +14,8 @@ def register(
     manager_name -- class attribute name to use for historical manager
     records_class -- class to use for history relation (defaults to
         HistoricalRecords)
+    table_name -- Custom name for history table (defaults to
+        'APPNAME_historicalMODELNAME')
 
     This method should be used as an alternative to attaching an
     `HistoricalManager` instance directly to `model`.
@@ -24,6 +26,7 @@ def register(
             records_class = models.HistoricalRecords
         records = records_class(**records_config)
         records.manager_name = manager_name
+        records.table_name = table_name
         records.module = app and ("%s.models" % app) or model.__module__
         records.add_extra_methods(model)
         records.finalize(model)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -44,9 +44,10 @@ class HistoricalRecords(object):
     thread = threading.local()
 
     def __init__(self, verbose_name=None, bases=(models.Model,),
-                 user_related_name='+'):
+                 user_related_name='+', table_name=None):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
+        self.table_name = table_name
         try:
             if isinstance(bases, six.string_types):
                 raise TypeError
@@ -117,9 +118,8 @@ class HistoricalRecords(object):
         attrs.update(self.get_extra_fields(model, fields))
         # type in python2 wants str as a first argument
         attrs.update(Meta=type(str('Meta'), (), self.get_meta_options(model)))
-        history_options = self.get_history_options(model)
-        if 'db_history_table' in history_options:
-            attrs['Meta'].db_table = history_options['db_history_table']
+        if self.table_name is not None:
+            attrs['Meta'].db_table = self.table_name
         name = 'Historical%s' % model._meta.object_name
         registered_models[model._meta.db_table] = model
         return python_2_unicode_compatible(
@@ -227,27 +227,6 @@ class HistoricalRecords(object):
                                  smart_text(model._meta.verbose_name))
         meta_fields['verbose_name'] = name
         return meta_fields
-
-    def get_history_options(self, model):
-        """
-        Returns a dictionary of options set to the History inner
-        class of the historical record model.
-        """
-        VALID_OPTIONS = ['db_history_table']
-        if hasattr(model, 'History'):
-            history_options = model.History.__dict__.copy()
-            for key in model.History.__dict__:
-                # Ignore any private attributes that we doesn't care about, like
-                # "__module__" or "__dict__".
-                # NOTE: We can't modify a dictionary's contents while looping
-                # over it, so we loop over the *original* dictionary instead.
-                if key.startswith('_'):
-                    del history_options[key]
-            for option in history_options:
-                if not option in VALID_OPTIONS:
-                    raise TypeError("'class History' got invalid attribute: %s" % (option,))
-            return history_options
-        return {}
 
     def post_save(self, instance, created, **kwargs):
         if not created and hasattr(instance, 'skip_history_when_saving'):

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -264,3 +264,11 @@ class Province(models.Model):
 class City(models.Model):
     country = models.ForeignKey(Country, db_column='countryCode')
     history = HistoricalRecords()
+
+class Contact(models.Model):
+    name = models.CharField(max_length=30)
+    email = models.EmailField(max_length=255, unique=True)
+    history = HistoricalRecords()
+
+    class History:
+        db_history_table = 'contacts_history'

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -268,7 +268,10 @@ class City(models.Model):
 class Contact(models.Model):
     name = models.CharField(max_length=30)
     email = models.EmailField(max_length=255, unique=True)
-    history = HistoricalRecords()
+    history = HistoricalRecords(table_name='contacts_history')
 
-    class History:
-        db_history_table = 'contacts_history'
+class ContactRegister(models.Model):
+    name = models.CharField(max_length=30)
+    email = models.EmailField(max_length=255, unique=True)
+
+register(ContactRegister, table_name='contacts_register_history')

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -19,7 +19,7 @@ from ..models import (
     ExternalModel1, ExternalModel3, UnicodeVerboseName, HistoricalChoice,
     HistoricalState, HistoricalCustomFKError, Series, SeriesWork, PollInfo,
     UserAccessorDefault, UserAccessorOverride, Employee, Country, Province,
-    City, Contact
+    City, Contact, ContactRegister
 )
 from ..external.models import ExternalModel2, ExternalModel4
 
@@ -746,9 +746,16 @@ class TestMissingOneToOne(TestCase):
         with self.assertRaises(Employee.DoesNotExist):
             original.manager
 
-class CustomTableNameTest(TestCase):
+class CustomTableNameTest1(TestCase):
     def get_table_name(self, manager):
         return manager.model._meta.db_table
     
     def test_custom_table_name(self):
         self.assertEqual(self.get_table_name(Contact.history), 'contacts_history')
+
+class CustomTableNameTest2(TestCase):
+    def get_table_name(self, manager):
+        return manager.model._meta.db_table
+    
+    def test_custom_table_name(self):
+        self.assertEqual(self.get_table_name(ContactRegister.history), 'contacts_register_history')

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -19,7 +19,7 @@ from ..models import (
     ExternalModel1, ExternalModel3, UnicodeVerboseName, HistoricalChoice,
     HistoricalState, HistoricalCustomFKError, Series, SeriesWork, PollInfo,
     UserAccessorDefault, UserAccessorOverride, Employee, Country, Province,
-    City
+    City, Contact
 )
 from ..external.models import ExternalModel2, ExternalModel4
 
@@ -745,3 +745,10 @@ class TestMissingOneToOne(TestCase):
         self.assertEqual(original.manager_id, 1)
         with self.assertRaises(Employee.DoesNotExist):
             original.manager
+
+class CustomTableNameTest(TestCase):
+    def get_table_name(self, manager):
+        return manager.model._meta.db_table
+    
+    def test_custom_table_name(self):
+        self.assertEqual(self.get_table_name(Contact.history), 'contacts_history')


### PR DESCRIPTION
Currently, the history table name is hardcoded (APP_historicalMODEL).
This pull request add support for custom tables names by adding a
`db_history_table` option.

As Django reject all unknown option in `Meta` inner class, I've added an
`History` inner class to store this option (and possibly others future
options).

```
class Organization(models.Model):
    name    = models.CharField(_('Organization or Name'), max_length=25)
    address = models.CharField(_('Address'), max_length=250)
    zipcode = models.CharField(_('Postal code'), max_length=10, null=True)
    city    = models.CharField(_('City'), max_length=50)
    country = models.CharField(_('Country'), max_length=2, \
                choices=COUNTRIES_CHOICES)
    history = HistoricalRecords()

    def __str__(self):
        return self.name

    class History:
        db_history_table = 'organizations_history'

    class Meta:
        db_table = 'organizations'
```
