### PR TITLE
Add Django 1.9 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ charset = utf-8
 indent_style = space
 end_of_line = lf
 insert_final_newline = true
+max_line_length = 79
 trim_trailing_whitespace = true
 
 [*.{py,rst,ini}]

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ env:
   - DJANGO="Django>=1.9a,<1.10"
 
 install:
-  - pip install -U 'coverage<4' codecov $DJANGO
+  - pip install -U 'coverage<4' codecov
+  - pip install -U --pre $DJANGO
   - python -c 'from __future__ import print_function; import django; print("Django " + django.get_version())'
 
 script: coverage run setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
   - 3.2
   - 3.3
@@ -13,6 +12,7 @@ env:
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.8,<1.9"
+  - DJANGO="Django>=1.9a,<1.10"
 
 install:
   - pip install -U 'coverage<4' codecov $DJANGO
@@ -22,21 +22,25 @@ script: coverage run setup.py test
 
 matrix:
   exclude:
-   - python: 2.6
-     env: DJANGO="Django>=1.6,<1.7"
-   - python: 2.6
-     env: DJANGO="Django>=1.7,<1.8"
-   - python: 2.6
-     env: DJANGO="Django>=1.8,<1.9"
    - python: 3.2
      env: DJANGO="Django>=1.4,<1.5"
    - python: 3.3
      env: DJANGO="Django>=1.4,<1.5"
+   - python: 3.2
+     env: DJANGO="Django>=1.9a,<1.10"
+   - python: 3.3
+     env: DJANGO="Django>=1.9a,<1.10"
 
   include:
+   - python: 2.6
+     env: DJANGO="Django>=1.4,<1.5"
    - python: 3.4
      env: DJANGO="Django>=1.7,<1.8"
    - python: 3.4
      env: DJANGO="Django>=1.8,<1.9"
+   - python: 3.5
+     env: DJANGO="Django>=1.8,<1.9"
+   - python: 3.5
+     env: DJANGO="Django>=1.9a,<1.10"
 
 after_success: codecov

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ tip (unreleased)
 ----------------
 - Add ability to list history in admin when the object instance is deleted. (gh-72)
 - Add ability to change history through the admin. (Enabled with the `SIMPLE_HISTORY_EDIT` setting.)
+- Add Django 1.9 support.
 
 1.6.3 (2015-07-30)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ django-simple-history
 
 django-simple-history stores Django model state on every create/update/delete.
 
-This app requires Django 1.4.2, 1.6 or greater and Python 2.6 or greater.
+This app requires Django 1.4.2, 1.6, or greater and Python 2.6 or greater.
 
 Getting Help
 ------------

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ django-simple-history
 
 django-simple-history stores Django model state on every create/update/delete.
 
-This app requires Django 1.4.2 or greater and Python 2.6 or greater.
+This app requires Django 1.4.2, 1.6 or greater and Python 2.6 or greater.
 
 Getting Help
 ------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+# html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,7 +43,7 @@ settings:
     ]
 
 If you do not want to use the middleware, you can explicitly indicate
-the user making the change as documented in :ref:`recording_user`.
+the user making the change as documented in :doc:`/advanced`.
 
 Models
 ~~~~~~
@@ -121,7 +121,7 @@ An example of admin integration for the ``Poll`` and ``Choice`` models:
     admin.site.register(Poll, SimpleHistoryAdmin)
     admin.site.register(Choice, SimpleHistoryAdmin)
 
-Changing a history-tracked model from the admin interface will automatically record the user who made the change (see :ref:`recording_user`).
+Changing a history-tracked model from the admin interface will automatically record the user who made the change (see :doc:`/advanced`).
 
 
 Querying history

--- a/runtests.py
+++ b/runtests.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
-import sys
-from shutil import rmtree
+import logging
 from os.path import abspath, dirname, join
+from shutil import rmtree
+import sys
+import warnings
 
 import django
 from django.conf import settings
 
-
 sys.path.insert(0, abspath(dirname(__file__)))
-
 
 media_root = join(abspath(dirname(__file__)), 'test_files')
 rmtree(media_root, ignore_errors=True)
@@ -39,6 +39,10 @@ DEFAULT_SETTINGS = dict(
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
     ],
+    TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    }],
 )
 
 if django.VERSION >= (1, 5):
@@ -62,4 +66,5 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig()
     main()

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@ from setuptools import setup
 import simple_history
 
 tests_require = [
-    "Django>=1.4", "webtest==2.0.6", "django-webtest==1.7", "mock==1.0.1"
-]
+    'Django>=1.4', 'WebTest==2.0.18', 'django-webtest==1.7.8', 'mock==1.0.1']
 try:
     from unittest import skipUnless
 except ImportError:  # Python 2.6 compatibility

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ setup(
     author_email='corey@qr7.com',
     maintainer='Trey Hunner',
     url='https://github.com/treyhunner/django-simple-history',
-    packages=["simple_history", "simple_history.management", "simple_history.management.commands"],
+    packages=[
+        'simple_history', 'simple_history.management',
+        'simple_history.management.commands', 'simple_history.templatetags'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",

--- a/simple_history/templates/simple_history/object_history.html
+++ b/simple_history/templates/simple_history/object_history.html
@@ -1,6 +1,6 @@
 {% extends "admin/object_history.html" %}
 {% load i18n %}
-{% load url from future %}
+{% load url from simple_history_compat %}
 {% load admin_urls %}
 
 

--- a/simple_history/templates/simple_history/object_history_form.html
+++ b/simple_history/templates/simple_history/object_history_form.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
-{% load url from future %}
+{% load url from simple_history_compat %}
 
 {% block breadcrumbs %}
   <div class="breadcrumbs">

--- a/simple_history/templatetags/simple_history_compat.py
+++ b/simple_history/templatetags/simple_history_compat.py
@@ -1,0 +1,10 @@
+from django import template
+
+try:  # Django < 1.5
+    from django.templatetags.future import url
+except ImportError:
+    from django.template.defaulttags import url
+
+register = template.Library()
+
+register.tag(url)

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -429,7 +429,7 @@ class AdminSiteTest(WebTest):
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',
             'change_url': ANY,
-            'history_url': '/admin/tests/poll/{}/history/'.format(poll.pk),
+            'history_url': '/admin/tests/poll/{pk}/history/'.format(pk=poll.pk),
             'add': False,
             'change': True,
             'has_add_permission': admin.has_add_permission(request),

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -1,9 +1,8 @@
 from datetime import datetime, timedelta
 
-from mock import patch, MagicMock, PropertyMock, ANY
+from mock import patch, ANY
 from django_webtest import WebTest
 from django.contrib.admin import AdminSite
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
@@ -248,9 +247,8 @@ class AdminSiteTest(WebTest):
         self.assertEqual(historical_poll.history_user, None)
 
     def test_missing_one_to_one(self):
-        """
-        A relation to a missing one-to-one model should still show history
-        """
+        """A relation to a missing one-to-one model should still show
+        history"""
         self.login()
         manager = Employee.objects.create()
         employee = Employee.objects.create(manager=manager)
@@ -315,7 +313,8 @@ class AdminSiteTest(WebTest):
         response = admin.response_change(request, poll)
 
         with patch(
-                'simple_history.admin.ModelAdmin.response_change') as m_admin:
+            'simple_history.admin.admin.ModelAdmin.response_change'
+        ) as m_admin:
             m_admin.return_value = 'it was called'
             response = admin.response_change(request, poll)
 
@@ -335,7 +334,8 @@ class AdminSiteTest(WebTest):
         admin = SimpleHistoryAdmin(Poll, admin_site)
 
         with patch(
-                'simple_history.admin.ModelAdmin.response_change') as m_admin:
+            'simple_history.admin.admin.ModelAdmin.response_change'
+        ) as m_admin:
             m_admin.return_value = 'it was called'
             response = admin.response_change(request, poll)
 
@@ -372,7 +372,7 @@ class AdminSiteTest(WebTest):
             'app_label': 'tests',
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',
-            'change_url': '/admin/tests/poll/1/',
+            'change_url': ANY,
             'history_url': '/admin/tests/poll/1/history/',
             'add': False,
             'change': True,
@@ -416,10 +416,10 @@ class AdminSiteTest(WebTest):
 
         context = {
             # Verify this is set for history object not poll object
-            'original': history,
+            'original': history.instance,
             'change_history': True,
 
-            'title': 'Revert %s' % force_text(history),
+            'title': 'Revert %s' % force_text(history.instance),
             'adminform': ANY,
             'object_id': poll.id,
             'is_popup': False,
@@ -428,8 +428,8 @@ class AdminSiteTest(WebTest):
             'app_label': 'tests',
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',
-            'change_url': '/admin/tests/poll/2/',
-            'history_url': '/admin/tests/poll/2/history/',
+            'change_url': ANY,
+            'history_url': '/admin/tests/poll/{}/history/'.format(poll.pk),
             'add': False,
             'change': True,
             'has_add_permission': admin.has_add_permission(request),
@@ -484,7 +484,7 @@ class AdminSiteTest(WebTest):
             'app_label': 'tests',
             'original_opts': ANY,
             'changelist_url': '/admin/tests/poll/',
-            'change_url': '/admin/tests/poll/1/',
+            'change_url': ANY,
             'history_url': '/admin/tests/poll/1/history/',
             'add': False,
             'change': True,

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,16 @@ envlist =
     py{26,27}-django14,
     py{26,27,32,33}-django16,
     py{27,32,33,34}-django17,
-    py{27,32,33,34}-django18,
-    py{27,32,33,34}-djangotrunk,
+    py{27,32,33,34,35}-django18,
+    py{27,34,35}-django19,
+    py{27,34,35}-djangotrunk,
     docs, flake8
 
 
 [flake8]
 ignore = N802
-max-complexity = 10
-exclude = __init__.py
+max-complexity = 11
+exclude = __init__.py,simple_history/tests/migration_test_app/migrations/*
 
 
 [testenv:flake8]
@@ -34,5 +35,6 @@ deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9a,<1.10
     djangotrunk: https://github.com/django/django/tarball/master
 commands = coverage run -a --branch setup.py test


### PR DESCRIPTION
This should make everything work with Django 1.9. I also turned on warnings output to console when running the tests directly with `runtests.py`, and addressed some future warnings for 1.10. The changes didn't seem significant enough to drop 1.4 support, but we should consider doing it on the next minor release.