### PR TITLE
Remove unnecessary parameter current_app

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,6 +27,7 @@ Authors
 - Rajesh Pappula
 - Rod Xavier Bondoc
 - Ross Lote
+- Skuli Arnlaugsson
 - Steven Klass
 - Trey Hunner
 - Ulysses Vilela

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+1.8.1 (2016-03-13)
+------------------
+- Fix deprecation warning because of parameter `current_app` in `render`.
+
 1.8.0 (2016-02-02)
 ------------------
 - History tracking can be inherited by passing `inherit=True`. (gh-63)

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'
 
 
 def register(

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -76,7 +76,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         }
         context.update(extra_context or {})
         return render(request, template_name=self.object_history_template,
-                      dictionary=context, current_app=request.current_app)
+                      dictionary=context)
 
     def response_change(self, request, obj):
         if '_change_history' in request.POST and SIMPLE_HISTORY_EDIT:
@@ -179,7 +179,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             'root_path': getattr(self.admin_site, 'root_path', None),
         }
         return render(request, template_name=self.object_history_form_template,
-                      dictionary=context, current_app=request.current_app)
+                      dictionary=context)
 
     def save_model(self, request, obj, form, change):
         """Set special model attribute to user for reference after save"""

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -386,7 +386,7 @@ class AdminSiteTest(WebTest):
 
         mock_render.assert_called_once_with(
             request, template_name=admin.object_history_form_template,
-            dictionary=context, current_app=admin_site.name)
+            dictionary=context)
 
     def test_history_form_view_getting_history(self):
         request = RequestFactory().post('/')
@@ -443,7 +443,7 @@ class AdminSiteTest(WebTest):
 
         mock_render.assert_called_once_with(
             request, template_name=admin.object_history_form_template,
-            dictionary=context, current_app=admin_site.name)
+            dictionary=context)
 
     def test_history_form_view_getting_history_with_setting_off(self):
         request = RequestFactory().post('/')
@@ -499,4 +499,4 @@ class AdminSiteTest(WebTest):
 
         mock_render.assert_called_once_with(
             request, template_name=admin.object_history_form_template,
-            dictionary=context, current_app=admin_site.name)
+            dictionary=context)


### PR DESCRIPTION
Deprecated in Django 1.8. It's already set with:

```python
request.current_app = self.admin_site.name
```

This PR removes the warning:

> RemovedInDjango110Warning: The current_app argument of render is deprecated. Set the current_app attribute of request instead.