### PR TITLE
Unset middleware request

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ Authors
 - Trey Hunner
 - Ulysses Vilela
 - vnagendra
+- Lucas Wiman
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+1.8.1 (2016-03-17)
+------------------
+- Clear the threadlocal request object when processing the response to prevent test interactions. (gh-213)
+
 1.8.0 (2016-02-02)
 ------------------
 - History tracking can be inherited by passing `inherit=True`. (gh-63)

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'
 
 
 def register(

--- a/simple_history/middleware.py
+++ b/simple_history/middleware.py
@@ -11,3 +11,8 @@ class HistoryRequestMiddleware(object):
 
     def process_request(self, request):
         HistoricalRecords.thread.request = request
+
+    def process_response(self, request, response):
+        if hasattr(HistoricalRecords.thread, 'request'):
+            del HistoricalRecords.thread.request
+        return response

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -185,7 +185,6 @@ class AdminSiteTest(WebTest):
         )
 
     def test_middleware_saves_user(self):
-        Book.objects.all().delete()
         overridden_settings = {
             'MIDDLEWARE_CLASSES':
                 settings.MIDDLEWARE_CLASSES


### PR DESCRIPTION
@treyhunner This pull request adds a `process_response` method to `HistoryRequestMiddleware` to unset the threadlocal request attribute when a response is processed. See also https://github.com/jedie/django-tools/pull/7, where I did something similar. This behavior means there are no side-effects on global state which are not cleared by the django `TestCase` class.

## Testing

I added tests for the desired behavior, including a regression test (`test_rolled_back_user_does_not_lead_to_foreign_key_error`) simulating the following scenario:
- A test executes, creates a user `U` and simulates that user saving a model instance in an admin form. This sets the `HistoricalRecords.thread.request` variable to a request instance referencing the user.
- The Django TestCase rolling back the creation of the user so that `U` doesn't exist in the database anymore. (Or, the user entry is deleted.)
- A new test executes, running only backend code. The `history_user` foreign key is set to a `User` that does not exist in the database, failing with the following error:
```pytb
Traceback (most recent call last):
  File "/Users/lucaswiman/opensource/django-simple-history/simple_history/tests/tests/test_admin.py", line 231, in test_rolled_back_user_does_not_lead_to_foreign_key_error
    historical_book.history_user,
  File "/Users/lucaswiman/opensource/django-simple-history/.tox/py27-django19/lib/python2.7/site-packages/django/db/models/fields/related_descriptors.py", line 169, in __get__
    rel_obj = qs.get()
  File "/Users/lucaswiman/opensource/django-simple-history/.tox/py27-django19/lib/python2.7/site-packages/django/db/models/query.py", line 387, in get
    self.model._meta.object_name
DoesNotExist: CustomUser matching query does not exist.
```