### PR TITLE
Allow filtering of as_of

### DIFF
--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -56,7 +56,7 @@ class HistoryManager(models.Manager):
                                              self.instance._meta.object_name)
         return self.instance.__class__(*values)
 
-    def as_of(self, date):
+    def as_of(self, date, **kwargs):
         """Get a snapshot as of a specific date.
 
         Returns an instance, or an iterable of the instances, of the
@@ -64,8 +64,8 @@ class HistoryManager(models.Manager):
         was present on the object on the date provided.
         """
         if not self.instance:
-            return self._as_of_set(date)
-        queryset = self.get_queryset().filter(history_date__lte=date)
+            return self._as_of_set(date, **kwargs)
+        queryset = self.get_queryset().filter(history_date__lte=date, **kwargs)
         try:
             history_obj = queryset[0]
         except IndexError:
@@ -78,10 +78,10 @@ class HistoryManager(models.Manager):
                 self.instance._meta.object_name)
         return history_obj.instance
 
-    def _as_of_set(self, date):
+    def _as_of_set(self, date, **kwargs):
         model = type(self.model().instance)  # a bit of a hack to get the model
         pk_attr = model._meta.pk.name
-        queryset = self.get_queryset().filter(history_date__lte=date)
+        queryset = self.get_queryset().filter(history_date__lte=date, **kwargs)
         for original_pk in set(
                 queryset.order_by().values_list(pk_attr, flat=True)):
             changes = queryset.filter(**{pk_attr: original_pk})

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -486,6 +486,22 @@ class HistoryManagerTest(TestCase):
         poll.delete()
         self.assertRaises(Poll.DoesNotExist, poll.history.as_of, time)
 
+    def test_as_of_filter(self):
+        poll1 = Poll.objects.create(question="what's up?", pub_date=today)
+        poll2 = Poll.objects.create(question="how's it going?", pub_date=today)
+        time = datetime.now()
+
+        poll1.question = "why?"
+        poll1.save()
+
+        polls_as_of = list(Poll.history.as_of(time, question="what's up?"))
+        self.assertEqual(len(polls_as_of), 1)
+
+        self.assertEqual(polls_as_of[0].question, "what's up?")
+
+        poll1.delete()
+        poll2.delete()
+
     def test_foreignkey_field(self):
         why_poll = Poll.objects.create(question="why?", pub_date=today)
         how_poll = Poll.objects.create(question="how?", pub_date=today)


### PR DESCRIPTION
Since as_of is a model level method, allowing filtering within the queryset.
