### PR TITLE
Added batch size option to the management command for populating the history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,6 +33,7 @@ Authors
 - Ulysses Vilela
 - vnagendra
 - Lucas Wiman
+- Michael England
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 tip (unreleased)
 ----------------
 - Add Polish locale.
+- Added --batchsize option to the populate_history management command.
 
 1.8.1 (2016-03-19)
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,6 +83,9 @@ initial change for preexisting model instances:
 
     $ python manage.py populate_history --auto
 
+By default, history rows are inserted in batches of 200. This can be changed if needed for large tables
+by using the ``--batchsize`` option, for example ``--batchsize 500``.
+
 .. _admin_integration:
 
 Integration with Django Admin
@@ -168,5 +171,5 @@ records for all ``Choice`` instances can be queried by using the manager on the
     <simple_history.manager.HistoryManager object at 0x1cc4290>
     >>> Choice.history.all()
     [<HistoricalChoice: Choice object as of 2010-10-25 18:05:12.183340>, <HistoricalChoice: Choice object as of 2010-10-25 18:04:59.047351>]
-    
+
 Because the history is model, you can also filter it like regulary QuerySets, a.k. Choice.history.filter(choice_text='Not Much') will work!

--- a/simple_history/management/commands/_populate_utils.py
+++ b/simple_history/management/commands/_populate_utils.py
@@ -15,7 +15,7 @@ def get_history_model_for_model(model):
     return getattr(model, manager_name).model
 
 
-def bulk_history_create(model, history_model):
+def bulk_history_create(model, history_model, batch_size):
     """Save a copy of all instances to the historical model."""
     historical_instances = [
         history_model(
@@ -26,4 +26,4 @@ def bulk_history_create(model, history_model):
                 for field in instance._meta.fields
             }
         ) for instance in model.objects.all()]
-    history_model.objects.bulk_create(historical_instances)
+    history_model.objects.bulk_create(historical_instances, batch_size=batch_size)

--- a/simple_history/management/commands/populate_history.py
+++ b/simple_history/management/commands/populate_history.py
@@ -36,6 +36,14 @@ class Command(BaseCommand):
             help="Automatically search for models with the "
                  "HistoricalRecords field type",
         ),
+        make_option(
+            '--batchsize',
+            action='store',
+            dest='batchsize',
+            default=200,
+            type=int,
+            help='Set a custom batch size when bulk inserting historical records.',
+        ),
     )
 
     def handle(self, *args, **options):
@@ -58,7 +66,7 @@ class Command(BaseCommand):
         else:
             self.stdout.write(self.COMMAND_HINT)
 
-        self._process(to_process)
+        self._process(to_process, batch_size=options['batchsize'])
 
     def _handle_model_list(self, *args):
         failing = False
@@ -94,7 +102,7 @@ class Command(BaseCommand):
                              " < {model} >\n".format(model=natural_key))
         return model, history_model
 
-    def _process(self, to_process):
+    def _process(self, to_process, batch_size):
         for model, history_model in to_process:
             if history_model.objects.count():
                 self.stderr.write("{msg} {model}\n".format(
@@ -103,5 +111,5 @@ class Command(BaseCommand):
                 ))
                 continue
             self.stdout.write(self.START_SAVING_FOR_MODEL.format(model=model))
-            utils.bulk_history_create(model, history_model)
+            utils.bulk_history_create(model, history_model, batch_size)
             self.stdout.write(self.DONE_SAVING_FOR_MODEL.format(model=model))

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -57,6 +57,14 @@ class TestPopulateHistory(TestCase):
                                 stdout=StringIO(), stderr=StringIO())
         self.assertEqual(models.Poll.history.all().count(), 1)
 
+    def test_populate_with_custom_batch_size(self):
+        models.Poll.objects.create(question="Will this populate?",
+                                   pub_date=datetime.now())
+        models.Poll.history.all().delete()
+        management.call_command(self.command_name, auto=True, batchsize=500,
+                                stdout=StringIO(), stderr=StringIO())
+        self.assertEqual(models.Poll.history.all().count(), 1)
+
     def test_specific_populate(self):
         models.Poll.objects.create(question="Will this populate?",
                                    pub_date=datetime.now())


### PR DESCRIPTION
Currently, if you try and populate the history of a large table Django raises a 'lost connection to MySQL server' error. This is because the bulk_create method is not given a batch size.

This pull request adds an additional parameter to the management command (--batchsize), where you can specify this e.g. 500. I have set the default value to a reasonable 200. Issue #202 and #189 should be fixed in this pull request.
