### PR TITLE
Django 1.10 compatibility for admin.py

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -76,7 +76,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         }
         context.update(extra_context or {})
         return render(request, template_name=self.object_history_template,
-                      dictionary=context, current_app=request.current_app)
+                      context=context)
 
     def response_change(self, request, obj):
         if '_change_history' in request.POST and SIMPLE_HISTORY_EDIT:
@@ -179,7 +179,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             'root_path': getattr(self.admin_site, 'root_path', None),
         }
         return render(request, template_name=self.object_history_form_template,
-                      dictionary=context, current_app=request.current_app)
+                      context=context)
 
     def save_model(self, request, obj, form, change):
         """Set special model attribute to user for reference after save"""


### PR DESCRIPTION
Parameters for `render()` have changed (deprecated in 1.8, removed in 1.10):
- `dictionary` was renamed to `context`
- `current_app` was removed, instead `request.current_app` should be set.

I have not tested with older releases yet, but according to the docs, it should work down to 1.8 when the changes were introduced.
