### PR TITLE
Check that request.user is a user model that we can save

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -8,6 +8,7 @@ from django.db import models, router
 from django.db.models.fields.proxy import OrderWrt
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth import get_user_model
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.encoding import smart_text
@@ -258,8 +259,9 @@ class HistoricalRecords(object):
             return instance._history_user
         except AttributeError:
             try:
-                if self.thread.request.user.is_authenticated():
-                    return self.thread.request.user
+                user = self.thread.request.user
+                if isinstance(user, get_user_model()) and user.is_authenticated():
+                    return user
                 return None
             except AttributeError:
                 return None


### PR DESCRIPTION
If request.user isn't the same as AUTH_USER_MODEL for some reason, then injecting the user into the history model will fail.

Fixes #245