### PR TITLE
Added edit_history option to HistoryManager.as_of(). 

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -23,7 +23,12 @@ as_of
 ~~~~~
 
 This method will return an instance of the model as it would have existed at
-the provided date and time.
+the provided date and time. Modifying and saving this instance will revert the
+parent instance to the instance snapshot you are saving, creating a new
+historical record at the current time.
+
+Specifying ``edit_history=True`` returns the equivalent historical object
+record, which can be deleted or updated to edit history.
 
 .. code-block:: pycon
 
@@ -32,6 +37,8 @@ the provided date and time.
     <Poll: Poll object as of 2010-10-25 18:03:29.855689>
     >>> poll.history.as_of(datetime(2010, 10, 25, 18, 5, 0))
     <Poll: Poll object as of 2010-10-25 18:04:13.814128>
+    >>> poll.history.as_of(datetime(2010, 10, 25, 18, 5, 0), edit_history=True)
+    <HistoricalPoll: Poll object as of 2010-10-25 18:04:13.814128>
 
 most_recent
 ~~~~~~~~~~~

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -56,15 +56,19 @@ class HistoryManager(models.Manager):
                                              self.instance._meta.object_name)
         return self.instance.__class__(*values)
 
-    def as_of(self, date):
+    def as_of(self, date, edit_history=False):
         """Get a snapshot as of a specific date.
 
         Returns an instance, or an iterable of the instances, of the
         original model with all the attributes set according to what
         was present on the object on the date provided.
+
+        When edit_history is enabled, historical objects (which can be updated
+        to modify history) are returned, rather than instances of the original
+        object type. Otherwise, saving will create new history objects.
         """
         if not self.instance:
-            return self._as_of_set(date)
+            return self._as_of_set(date, edit_history)
         queryset = self.get_queryset().filter(history_date__lte=date)
         try:
             history_obj = queryset[0]
@@ -76,9 +80,12 @@ class HistoryManager(models.Manager):
             raise self.instance.DoesNotExist(
                 "%s had already been deleted." %
                 self.instance._meta.object_name)
-        return history_obj.instance
+        if edit_history:
+            return history_obj
+        else:
+            return history_obj.instance
 
-    def _as_of_set(self, date):
+    def _as_of_set(self, date, edit_history=False):
         model = type(self.model().instance)  # a bit of a hack to get the model
         pk_attr = model._meta.pk.name
         queryset = self.get_queryset().filter(history_date__lte=date)
@@ -89,4 +96,7 @@ class HistoryManager(models.Manager):
             if changes.filter(history_date=last_change.history_date,
                               history_type='-').exists():
                 continue
-            yield last_change.instance
+            if edit_history:
+                yield last_change
+            else:
+                yield last_change.instance

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -86,3 +86,18 @@ class AsOfAdditionalTestCase(TestCase):
         historical = models.Document.history.as_of(datetime.now()
                                                    + timedelta(days=1))
         self.assertEqual(list(historical), [document1, document2])
+
+    def test_edit_history(self):
+        document = models.Document.objects.create()
+        hist_doc = document.history.as_of(datetime.now(), edit_history=True)
+        self.assertNotEqual(type(document), type(hist_doc))
+        self.assertLess(hist_doc.history_date, datetime.now())
+
+    def test_edit_history_multiple(self):
+        doc1 = models.Document.objects.create()
+        doc2 = models.Document.objects.create()
+        historical = models.Document.history.as_of(datetime.now()
+                                                   + timedelta(days=1),
+                                                   edit_history=True)
+        first_histories = [doc1.history.first(), doc2.history.first()]
+        self.assertEqual(list(historical), first_histories)


### PR DESCRIPTION
Currently, the history manager's `as_of` method returns instances of the original model type. This means when trying to edit history, filtering and dealing with DoesNotExist errors has to be done manually. This adds getting HistoricalObject instances as of a certain time right in.

From the docstring:

> When edit_history is enabled, historical objects (which can be updated
> to modify history) are returned, rather than instances of the original
> object type. Otherwise, saving will create new history objects.

Not sure how I would set up a test for the returned instance's class, mainly because Historical<Object> classes are defined on the fly. Feedback welcome, thanks.