### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ This app requires Django 1.6 or greater and Python 2.7, 3.3, or greater.
 Getting Help
 ------------
 
-Documentation is available at https://django-simple-history.readthedocs.org/
+Documentation is available at https://django-simple-history.readthedocs.io/
 
 Issue tracker is at https://github.com/treyhunner/django-simple-history/issues
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.