### PR TITLE
Fix i18n bugs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,6 +10,7 @@ Authors
 - Daniel Levy
 - Daniel Roschka
 - David Hite
+- Eduardo Cuducos
 - George Vilches
 - Grzegorz Bialy
 - Hamish Downer

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include MANIFEST.in
 include *.rst
 include *.txt
 recursive-include docs *.rst
+recursive-include simple_history/locale *
 recursive-include simple_history/templates *

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -12,7 +12,7 @@ from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.encoding import smart_text
 from django.utils.timezone import now
-from django.utils.translation import string_concat
+from django.utils.translation import string_concat, ugettext as _
 
 try:
     from django.apps import apps
@@ -206,9 +206,9 @@ class HistoricalRecords(object):
                 user_model, null=True, related_name=self.user_related_name,
                 on_delete=models.SET_NULL),
             'history_type': models.CharField(max_length=1, choices=(
-                ('+', 'Created'),
-                ('~', 'Changed'),
-                ('-', 'Deleted'),
+                ('+', _('Created')),
+                ('~', _('Changed')),
+                ('-', _('Deleted')),
             )),
             'history_object': HistoricalObjectDescriptor(model),
             'instance': property(get_instance),

--- a/simple_history/templates/simple_history/object_history.html
+++ b/simple_history/templates/simple_history/object_history.html
@@ -35,7 +35,7 @@
                       {{ action.history_user }}
                     {% endif %}
                   {% else %}
-                    None
+                  {% trans "None" %}
                   {% endif %}
                 </td>
               </tr>


### PR DESCRIPTION
While working on #279 I noticed:

* that locale files where missing when the package was installed via `pip`, so I added them to `MANIFEST.in` (7ee9eaa)
* and that some tokens were not translated, so I added them to the `gettext` flow (4d36fdf)