### PR TITLE
Fix/issue293

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -280,31 +280,25 @@ Or you can pass the change reason explicitly:
     poll.save()
     update_change_reason(poll, 'Add a question')
 
-Save Without Historical Record
-------------------------------
+Save without a historical record
+--------------------------------
 
-You want save model without saving a historical record. You can use this method. 
-
-.. code-block:: python
-    def save_without_historical_record(self, *args, **kwargs):
-        self.skip_history_when_saving = True
-        try:
-            ret = self.save(*args, **kwargs)
-        finally:
-            del self.skip_history_when_saving
-        return ret
-       
+If you want to save a model without a historical record, you can use the following:
 
 .. code-block:: python
+
     class Poll(models.Model):
         question = models.CharField(max_length=200)
         history = HistoricalRecords()
 
+        def save_without_historical_record(self, *args, **kwargs):
+            self.skip_history_when_saving = True
+            try:
+                ret = self.save(*args, **kwargs)
+            finally:
+                del self.skip_history_when_saving
+            return ret
 
-.. code-block:: python
-    poll = Poll(quetions='somthing')
+
+    poll = Poll(question='something')
     poll.save_without_historical_record()
-
-
-
-


### PR DESCRIPTION
Fixes #293 

Notes: 

- I have not verified the actual code, but I would recommend someone double-checks this: the original example code had the method definition `def save_without_historical_record(self, *args, **kwargs):` *outside* the class definition, and was thus invalid. It also contained a few typos, further invalidating the code sample.

- I have not updated the changes file: it doesn't look like documentation changes, or simply minor fixes, are kept in there.