### PR TITLE
Switch ugettext to ugettext_lazy in models.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,6 +38,7 @@ Authors
 - Lucas Wiman
 - Michael England
 - Gregory Bataille
+- Jesse Shapiro
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+----------
+- Change ugettext calls in models.py to ugettext_lazy
+
 1.9.0 (2017-06-11)
 ------------------
 - Add --batchsize option to the populate_history management command. (gh-231)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -11,7 +11,7 @@ from django.db.models.fields.proxy import OrderWrt
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.timezone import now
-from django.utils.translation import string_concat, ugettext as _
+from django.utils.translation import string_concat, ugettext_lazy as _
 
 from . import exceptions
 from .manager import HistoryDescriptor


### PR DESCRIPTION
Fixes #288.

We have a use case where we need to import this package before the app registry is ready. This pull request changes `ugettext` calls in `models.py` to `ugettext_lazy`.

If we can get this in a 1.9.1 release soon, that'd be great, but if not, then we can just point at the master hash once it's merged.

@itsjeyd, can you check this code for me?