### PR TITLE
Use get_queryset rather than model.objects

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,7 @@ Authors
 - Rod Xavier Bondoc
 - Ross Lote
 - Steven Klass
+- Steeve Chailloux
 - Trey Hunner
 - Ulysses Vilela
 - vnagendra

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changes
 =======
 
+- Use get_queryset rather than model.objects in history_view. (gh-303)
+
 1.9.0 (2017-06-11)
 ------------------
 - Add --batchsize option to the populate_history management command. (gh-231)

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -60,7 +60,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         history_list_display = getattr(self, "history_list_display", [])
         # If no history was found, see whether this object even exists.
         try:
-            obj = model.objects.get(**{pk_name: object_id})
+            obj = self.get_queryset(request).get(**{pk_name: object_id})
         except model.DoesNotExist:
             try:
                 obj = action_list.latest('history_date').instance


### PR DESCRIPTION
This able user to overwrite `get_queryset` safely.

For example I've got a meta model for soft delete, with a boolean `is_void`, which is by default filtered to `False` by meta model manager `get_queryset` method, note that this manager defined also a method `all_include_void`, so in the model admin I can use this latest method in model admin `get_queryset`, but without this fix it just doesn't work as expected.

let me know your thoughts.