### PR TITLE
fix mongodb engine check

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,6 +40,7 @@ Authors
 - Michael England
 - Gregory Bataille
 - Jesse Shapiro
+- Shane Engelman
 
 Background
 ==========

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -312,7 +312,7 @@ def convert_auto_field(field):
     must be replaced with an IntegerField.
     """
     connection = router.db_for_write(field.model)
-    if settings.DATABASES[connection]['ENGINE'] in ('django_mongodb_engine',):
+    if settings.DATABASES[connection].get('ENGINE') in ('django_mongodb_engine',):
         # Check if AutoField is string for django-non-rel support
         return models.TextField
     return models.IntegerField


### PR DESCRIPTION
models.py line 315
`if settings.DATABASES[connection]['ENGINE'] in ('django_mongodb_engine',):`
can throw a KeyError if the project configuration does not follow
Django docs guidelines for setup

Legacy projects can potentially have a working Django app set up like this:
```python
DATABASES = {
    'default': dj_config_url.config(env='DATABASE_URL'),
    'alternative': dj_config_url.config(env='ALTERNATIVE_DATABASE_URL'),
}
```

Considering that during a migration for simple_history, models.py
checks for a key that does not exist, an exception is thrown that
prevents the project from running.