### PR TITLE
Add support for admin inlines

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,6 +40,7 @@ Authors
 - Michael England
 - Gregory Bataille
 - Jesse Shapiro
+- Mathieu Hentges
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Unreleased
 ----------
 - Use get_queryset rather than model.objects in history_view. (gh-303)
 - Change ugettext calls in models.py to ugettext_lazy
-- Add ability of displaying inlines in the admin history form view
+- Add ability to display inlines in the admin history form view
 
 1.9.0 (2017-06-11)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 - Use get_queryset rather than model.objects in history_view. (gh-303)
 - Change ugettext calls in models.py to ugettext_lazy
+- Add ability of displaying inlines in the admin history form view
 
 1.9.0 (2017-06-11)
 ------------------

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -154,9 +154,31 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
 
         model_name = original_opts.model_name
         url_triplet = self.admin_site.name, original_opts.app_label, model_name
-        formset, inline_instances = self._create_formsets(request, obj,
-                                                          change=False)
-        inline_formsets = self.get_inline_formsets(
+
+        inline_instances = self.get_inline_instances(request, obj)
+        prefixes = {}
+        formset = []
+
+        for FormSet, inline in self.get_admin_formsets_with_inline(
+                *[request]):
+            prefix = FormSet.get_default_prefix()
+            prefixes[prefix] = prefixes.get(prefix, 0) + 1
+            if prefixes[prefix] != 1 or not prefix:
+                prefix = "%s-%s" % (prefix, prefixes[prefix])
+            formset_params = {
+                'instance': obj,
+                'prefix': prefix,
+                'queryset': inline.get_queryset(request),
+            }
+            if request.method == 'POST':
+                formset_params.update({
+                    'data': request.POST.copy(),
+                    'files': request.FILES,
+                    'save_as_new': '_saveasnew' in request.POST
+                })
+            formset.append(FormSet(**formset_params))
+
+        inline_formsets = self.get_admin_inline_formsets(
             request, formset, inline_instances, obj)
         context = {
             'title': _('Revert %s') % force_text(obj),
@@ -195,7 +217,33 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         extra_kwargs = {}
         if get_complete_version() < (1, 8):
             extra_kwargs['current_app'] = request.current_app
-        return render(request, self.object_history_form_template, context, **extra_kwargs)
+        return render(request,
+                      self.object_history_form_template,
+                      context,
+                      **extra_kwargs)
+
+    def get_admin_inline_formsets(self,
+                                  request,
+                                  formsets,
+                                  inline_instances,
+                                  obj=None):
+        """ Django < 1.7 """
+        inline_admin_formsets = []
+        for inline, formset in zip(inline_instances, formsets):
+            fieldsets = list(inline.get_fieldsets(request, obj))
+            readonly = list(inline.get_readonly_fields(request, obj))
+            prepopulated = dict(inline.get_prepopulated_fields(request, obj))
+            inline_admin_formset = helpers.InlineAdminFormSet(
+                inline, formset, fieldsets, prepopulated, readonly,
+                model_admin=self,
+            )
+            inline_admin_formsets.append(inline_admin_formset)
+        return inline_admin_formsets
+
+    def get_admin_formsets_with_inline(self, request, obj=None):
+        """ Django < 1.7 """
+        for inline in self.get_inline_instances(request, obj):
+            yield inline.get_formset(request, obj), inline
 
     def save_model(self, request, obj, form, change):
         """Set special model attribute to user for reference after save"""

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -154,6 +154,10 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
 
         model_name = original_opts.model_name
         url_triplet = self.admin_site.name, original_opts.app_label, model_name
+        formset, inline_instances = self._create_formsets(request, obj,
+                                                          change=False)
+        inline_formsets = self.get_inline_formsets(
+            request, formset, inline_instances, obj)
         context = {
             'title': _('Revert %s') % force_text(obj),
             'adminform': admin_form,
@@ -170,6 +174,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             'history_url': reverse('%s:%s_%s_history' % url_triplet,
                                    args=(obj.pk,)),
             'change_history': change_history,
+            'inline_admin_formsets': inline_formsets,
 
             # Context variables copied from render_change_form
             'add': False,

--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -23,6 +23,7 @@ class ChoiceAdmin(SimpleHistoryAdmin):
 class PollAdmin(SimpleHistoryAdmin):
     inlines = [ChoiceInline, ]
 
+
 admin.site.register(Choice, ChoiceAdmin)
 admin.site.register(Person, PersonAdmin)
 admin.site.register(Book, SimpleHistoryAdmin)
@@ -30,4 +31,3 @@ admin.site.register(Document, SimpleHistoryAdmin)
 admin.site.register(Paper, SimpleHistoryAdmin)
 admin.site.register(Employee, SimpleHistoryAdmin)
 admin.site.register(Poll, PollAdmin)
-

--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -21,8 +21,7 @@ class ChoiceAdmin(SimpleHistoryAdmin):
 
 
 class PollAdmin(SimpleHistoryAdmin):
-    inlines = [ChoiceInline, ]
-
+    inlines = [ChoiceInline, ChoiceInline]
 
 admin.site.register(Choice, ChoiceAdmin)
 admin.site.register(Person, PersonAdmin)

--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -6,6 +6,11 @@ from simple_history.admin import SimpleHistoryAdmin
 from .models import Poll, Choice, Person, Book, Document, Paper, Employee
 
 
+class ChoiceInline(admin.TabularInline):
+    model = Choice
+    extra = 1
+
+
 class PersonAdmin(SimpleHistoryAdmin):
     def has_change_permission(self, request, obj=None):
         return False
@@ -15,10 +20,14 @@ class ChoiceAdmin(SimpleHistoryAdmin):
     history_list_display = ['votes']
 
 
-admin.site.register(Poll, SimpleHistoryAdmin)
+class PollAdmin(SimpleHistoryAdmin):
+    inlines = [ChoiceInline, ]
+
 admin.site.register(Choice, ChoiceAdmin)
 admin.site.register(Person, PersonAdmin)
 admin.site.register(Book, SimpleHistoryAdmin)
 admin.site.register(Document, SimpleHistoryAdmin)
 admin.site.register(Paper, SimpleHistoryAdmin)
 admin.site.register(Employee, SimpleHistoryAdmin)
+admin.site.register(Poll, PollAdmin)
+

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -412,7 +412,7 @@ class AdminSiteTest(WebTest):
             # Verify this is set for original object
             'original': poll,
             'change_history': False,
-
+            'inline_admin_formsets': [],
             'title': 'Revert %s' % force_text(poll),
             'adminform': ANY,
             'object_id': poll.id,
@@ -466,7 +466,7 @@ class AdminSiteTest(WebTest):
             # Verify this is set for history object not poll object
             'original': history.instance,
             'change_history': True,
-
+            'inline_admin_formsets': [],
             'title': 'Revert %s' % force_text(history.instance),
             'adminform': ANY,
             'object_id': poll.id,
@@ -521,6 +521,7 @@ class AdminSiteTest(WebTest):
             # Verify this is set for history object not poll object
             'original': poll,
             'change_history': False,
+            'inline_admin_formsets': [],
 
             'title': 'Revert %s' % force_text(poll),
             'adminform': ANY,


### PR DESCRIPTION
The inlines couldn't be displayed in the admin form view. 

I added the 'inline_admin_formsets' entry in context to make them available.