### PR TITLE
Handle reverse move and models.permalink removal

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -6,7 +6,6 @@ from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render
 from django.utils.text import capfirst
 from django.utils.html import mark_safe
@@ -18,6 +17,10 @@ try:
     from django.contrib.admin.utils import unquote
 except ImportError:  # Django < 1.7
     from django.contrib.admin.util import unquote
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 1.10
+    from django.core.urlresolvers import reverse
 try:
     from django.utils.version import get_complete_version
 except ImportError:

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -21,6 +21,10 @@ try:
 except ImportError:  # Django < 1.7
     from django.db.models import get_app
 try:
+    from django.urls import reverse
+except ImportError:  # Django < 1.10
+    from django.core.urlresolvers import reverse
+try:
     from south.modelsinspector import add_introspection_rules
 except ImportError:  # south not present
     pass
@@ -204,14 +208,12 @@ class HistoricalRecords(object):
 
         user_model = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
-        @models.permalink
         def revert_url(self):
             """URL for this change in the default admin site."""
             opts = model._meta
             app_label, model_name = opts.app_label, opts.model_name
-            return ('%s:%s_%s_simple_history' %
-                    (admin.site.name, app_label, model_name),
-                    [getattr(self, opts.pk.attname), self.history_id])
+            viewname = '%s:%s_%s_simple_history' % (admin.site.name, app_label, model_name)
+            return reverse(viewname, args=[getattr(self, opts.pk.attname), self.history_id])
 
         def get_instance(self):
             return model(**{

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -6,7 +6,6 @@ from django.contrib.admin import AdminSite
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test.utils import override_settings
 from django.test.client import RequestFactory
-from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.encoding import force_text
@@ -19,6 +18,10 @@ try:
     from django.contrib.admin.utils import quote
 except ImportError:  # Django < 1.7
     from django.contrib.admin.util import quote
+try:
+    from django.urls import reverse
+except ImportError:  # Django < 1.10
+    from django.core.urlresolvers import reverse
 
 User = get_user_model()
 today = datetime(2021, 1, 1, 10, 0)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -343,6 +343,14 @@ class HistoricalRecordsTest(TestCase):
         self.assertIn('question', all_fields_names)
         self.assertNotIn('pub_date', all_fields_names)
 
+    def test_revert_url(self):
+        p = Poll(question="what's up?", pub_date=today)
+        p.save()
+        record = p.history.all()[0]
+        revert_url = record.revert_url()
+        expected_url = '/admin/tests/poll/{}/history/{}/'.format(p.id, record.id)
+        self.assertEqual(revert_url, expected_url)
+
 
 class CreateHistoryModelTests(unittest.TestCase):
 


### PR DESCRIPTION
This should handle two of the changes in recent Django versions mentioned in #291 -

* The move of `reverse()` from `django.core.urlresovers` to `django.urls`
* The removal of `models.permalink`

Compatibility with all currently supported Django versions should be maintained.  I realize that #320 also has a fix for the first point, but it seems to have gotten bogged down in figuring out how to handle some of the other changes; it might make sense to just merge these simple fixes first.