### PR TITLE
Add new constructor options to HistoricalRecords class

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,6 +44,7 @@ Authors
 - Jesse Shapiro
 - Kevin Foster
 - Shane Engelman
+- Ray Logel
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased
 - Use get_queryset rather than model.objects in history_view. (gh-303)
 - Change ugettext calls in models.py to ugettext_lazy
 - Resolve issue where model references itself (gh-278)
+- Add ability to specify custom history_id field 
+- Add ability to specify alternative user_model for tracking
 
 1.9.0 (2017-06-11)
 ------------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -127,6 +127,59 @@ referencing the ``changed_by`` field:
 
 Admin integration requires that you use a ``_history_user.setter`` attribute with your custom ``_history_user`` property (see :ref:`admin_integration`).
 
+Change User Model
+------------------------------------
+
+If you need to use a different user model then ``settings.AUTH_USER_MODEL``,
+pass in the required model to ``user_model``.  Doing this requires ``_history_user`` is provided.
+
+.. code-block:: python
+
+    from django.db import models
+    from simple_history.models import HistoricalRecords
+
+    class PollUser(models.Model):
+        user_id = models.ForeignKey('auth.User')
+
+
+    # Only PollUsers should be modifying a Poll
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        pub_date = models.DateTimeField('date published')
+        changed_by = models.ForeignKey(PollUser)
+        history = HistoricalRecords(user_model=PollUser)
+
+        @property
+        def _history_user(self):
+            return self.changed_by
+
+        @_history_user.setter
+        def _history_user(self, value):
+            self.changed_by = value
+
+Custom ``history_id``
+---------------------
+
+If you want to use something other then an ``AutoField`` for the history
+table primary key you can pass in a ``history_id_field``.  A common use case
+for this would be to use a ``UUIDField``.
+
+For any field provided it will automatically set ``primary_key=True`` and
+``editable=False``.
+
+.. code-block:: python
+
+    import uuid
+    from django.db import models
+    from simple_history.models import HistoricalRecords
+
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        pub_date = models.DateTimeField('date published')
+        history = HistoricalRecords(
+            history_id_field=models.UUIDField(default=uuid.uuid4)
+        )
+
 
 Custom ``history_date``
 -----------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -37,11 +37,14 @@ class HistoricalRecords(object):
 
     def __init__(self, verbose_name=None, bases=(models.Model,),
                  user_related_name='+', table_name=None, inherit=False,
+                 history_id_field=None, user_model=None,
                  excluded_fields=None):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
         self.table_name = table_name
         self.inherit = inherit
+        self.history_id_field = history_id_field
+        self.user_model = user_model
         if excluded_fields is None:
             excluded_fields = []
         self.excluded_fields = excluded_fields
@@ -202,7 +205,7 @@ class HistoricalRecords(object):
     def get_extra_fields(self, model, fields):
         """Return dict of extra fields added to the historical record model"""
 
-        user_model = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+        user_model = self.user_model or getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
         @models.permalink
         def revert_url(self):
@@ -219,8 +222,15 @@ class HistoricalRecords(object):
                 for field in fields.values()
             })
 
+        if self.history_id_field:
+            history_id_field = self.history_id_field
+            history_id_field.primary_key = True
+            history_id_field.editable = False
+        else:
+            history_id_field = models.AutoField(primary_key=True)
+
         return {
-            'history_id': models.AutoField(primary_key=True),
+            'history_id': history_id_field,
             'history_date': models.DateTimeField(),
             'history_change_reason': models.CharField(max_length=100,
                                                       null=True),

--- a/simple_history/registry_tests/tests.py
+++ b/simple_history/registry_tests/tests.py
@@ -79,28 +79,28 @@ class TestTrackingInheritance(TestCase):
 
     def test_tracked_abstract_base(self):
         self.assertEqual(
-            [
+            sorted([
                 f.attname
                 for f in TrackedWithAbstractBase.history.model._meta.fields
-            ],
-            [
+            ]),
+            sorted([
                 'id', 'history_id', 'history_date',
                 'history_change_reason', 'history_user_id',
                 'history_type',
-            ],
+            ]),
         )
 
     def test_tracked_concrete_base(self):
         self.assertEqual(
-            [
+            sorted([
                 f.attname
                 for f in TrackedWithConcreteBase.history.model._meta.fields
-            ],
-            [
+            ]),
+            sorted([
                 'id', 'trackedconcretebase_ptr_id', 'history_id',
                 'history_date', 'history_change_reason', 'history_user_id',
                 'history_type',
-            ],
+            ]),
         )
 
     def test_multiple_tracked_bases(self):
@@ -111,32 +111,41 @@ class TestTrackingInheritance(TestCase):
 
     def test_tracked_abstract_and_untracked_concrete_base(self):
         self.assertEqual(
-            [f.attname for f in InheritTracking1.history.model._meta.fields],
-            [
+            sorted([
+                f.attname
+                for f in InheritTracking1.history.model._meta.fields
+            ]),
+            sorted([
                 'id', 'untrackedconcretebase_ptr_id', 'history_id',
                 'history_date', 'history_change_reason',
                 'history_user_id', 'history_type',
-            ],
+            ]),
         )
 
     def test_indirect_tracked_abstract_base(self):
         self.assertEqual(
-            [f.attname for f in InheritTracking2.history.model._meta.fields],
-            [
+            sorted([
+                f.attname
+                for f in InheritTracking2.history.model._meta.fields
+            ]),
+            sorted([
                 'id', 'baseinherittracking2_ptr_id', 'history_id',
                 'history_date', 'history_change_reason',
                 'history_user_id', 'history_type',
-            ],
+            ]),
         )
 
     def test_indirect_tracked_concrete_base(self):
         self.assertEqual(
-            [f.attname for f in InheritTracking3.history.model._meta.fields],
-            [
+            sorted([
+                f.attname
+                for f in InheritTracking3.history.model._meta.fields
+            ]),
+            sorted([
                 'id', 'baseinherittracking3_ptr_id', 'history_id',
                 'history_date', 'history_change_reason',
                 'history_user_id', 'history_type',
-            ],
+            ]),
         )
 
     def test_registering_with_tracked_abstract_base(self):


### PR DESCRIPTION
- Provide history_id_field to change the field type for history_id
- Provide user_model to use an alternative model for tracking history_user