### PR TITLE
Correct module for history model of inherited model

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,6 +44,7 @@ Authors
 - Jesse Shapiro
 - Kevin Foster
 - Shane Engelman
+- Ray Logel
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 - Use get_queryset rather than model.objects in history_view. (gh-303)
 - Change ugettext calls in models.py to ugettext_lazy
 - Resolve issue where model references itself (gh-278)
+- History models for inherited models will be located in the same module as the inherited model
 
 1.9.0 (2017-06-11)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -76,13 +76,15 @@ class HistoricalRecords(object):
                 save_without_historical_record)
 
     def finalize(self, sender, **kwargs):
+        inherited = False
         try:
             hint_class = self.cls
         except AttributeError:  # called via `register`
             pass
         else:
             if hint_class is not sender:  # set in concrete
-                if not (self.inherit and issubclass(sender, hint_class)):
+                inherited = (self.inherit and issubclass(sender, hint_class))
+                if not inherited:
                     return  # set in abstract
         if hasattr(sender._meta, 'simple_history_manager_attribute'):
             raise exceptions.MultipleRegistrationsError(
@@ -91,8 +93,12 @@ class HistoricalRecords(object):
                     sender._meta.object_name,
                 )
             )
-        history_model = self.create_history_model(sender)
-        module = importlib.import_module(self.module)
+        history_model = self.create_history_model(sender, inherited)
+        if inherited:
+            # Make sure history model is in same module as inherited class
+            module = importlib.import_module(history_model.__module__)
+        else:
+            module = importlib.import_module(self.module)
         setattr(module, history_model.__name__, history_model)
 
         # The HistoricalRecords object will be discarded,
@@ -106,14 +112,18 @@ class HistoricalRecords(object):
         setattr(sender, self.manager_name, descriptor)
         sender._meta.simple_history_manager_attribute = self.manager_name
 
-    def create_history_model(self, model):
+    def create_history_model(self, model, inherited):
         """
         Creates a historical model to associate with the model provided.
         """
         attrs = {'__module__': self.module}
 
         app_module = '%s.models' % model._meta.app_label
-        if model.__module__ != self.module:
+
+        if inherited:
+            # inherited use models module
+            attrs['__module__'] = model.__module__
+        elif model.__module__ != self.module:
             # registered under different app
             attrs['__module__'] = self.module
         elif app_module != self.module:

--- a/simple_history/registry_tests/tests.py
+++ b/simple_history/registry_tests/tests.py
@@ -75,6 +75,21 @@ class TestUserAccessor(unittest.TestCase):
         assert hasattr(User, 'my_history_model_accessor')
 
 
+class TestInheritedModule(TestCase):
+
+    def test_using_app_label(self):
+        try:
+            from ..tests.models import HistoricalConcreteExternal
+        except ImportError:
+            self.fail("HistoricalConcreteExternal is in wrong module")
+
+    def test_default(self):
+        try:
+            from ..tests.models import HistoricalConcreteExternal2
+        except ImportError:
+            self.fail("HistoricalConcreteExternal2 is in wrong module")
+
+
 class TestTrackingInheritance(TestCase):
 
     def test_tracked_abstract_base(self):

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -367,6 +367,13 @@ class ConcreteExternal(AbstractExternal):
         app_label = 'tests'
 
 
+class ConcreteExternal2(AbstractExternal):
+    name = models.CharField(max_length=50)
+
+    class Meta:
+        pass    # Don't set app_label to test inherited module path
+
+
 class TrackedWithAbstractBase(TrackedAbstractBaseA):
     pass
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -350,7 +350,7 @@ class CreateHistoryModelTests(unittest.TestCase):
         records = HistoricalRecords()
         records.module = AdminProfile.__module__
         try:
-            records.create_history_model(AdminProfile)
+            records.create_history_model(AdminProfile, False)
         except:
             self.fail("SimpleHistory should handle foreign keys to one to one"
                       "fields to integer fields without throwing an exception")
@@ -359,7 +359,7 @@ class CreateHistoryModelTests(unittest.TestCase):
         records = HistoricalRecords()
         records.module = Bookcase.__module__
         try:
-            records.create_history_model(Bookcase)
+            records.create_history_model(Bookcase, False)
         except:
             self.fail("SimpleHistory should handle foreign keys to one to one"
                       "fields to char fields without throwing an exception.")
@@ -368,7 +368,7 @@ class CreateHistoryModelTests(unittest.TestCase):
         records = HistoricalRecords()
         records.module = MultiOneToOne.__module__
         try:
-            records.create_history_model(MultiOneToOne)
+            records.create_history_model(MultiOneToOne, False)
         except:
             self.fail("SimpleHistory should handle foreign keys to one to one"
                       "fields to one to one fields without throwing an "


### PR DESCRIPTION
If base model is in a different module the history model for the
inherited model should be in the same module as the inherited model