### PR TITLE
Remove support for Django 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
   - 3.6
 
 env:
-  - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
@@ -21,12 +20,5 @@ install:
   - pip freeze
 
 script: coverage run setup.py test
-
-matrix:
-  exclude:
-   - python: 3.5
-     env: DJANGO="Django>=1.7,<1.8"
-   - python: 3.6
-     env: DJANGO="Django>=1.7,<1.8"
 
 after_success: codecov

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changes
 =======
 
 1.9.1 (2018-03-30)
-----------
+------------------
 - Use get_queryset rather than model.objects in history_view. (gh-303)
 - Change ugettext calls in models.py to ugettext_lazy
 - Resolve issue where model references itself (gh-278)

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ django-simple-history
 
 django-simple-history stores Django model state on every create/update/delete.
 
-This app requires Django 1.7 or greater and Python 2.7, or 3.4 or greater.
+This app requires Django 1.8 or greater and Python 2.7, or 3.4 or greater.
 
 Getting Help
 ------------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import simple_history
 
 tests_require = [
-    'Django>=1.7', 'WebTest==2.0.24', 'django-webtest==1.8.0', 'mock==1.0.1']
+    'Django>=1.8', 'WebTest==2.0.24', 'django-webtest==1.8.0', 'mock==1.0.1']
 
 setup(
     name='django-simple-history',
@@ -24,6 +24,11 @@ setup(
         "Framework :: Django",
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
+        "Framework :: Django",
+        "Framework :: Django :: 1.8",
+        "Framework :: Django :: 1.9",
+        "Framework :: Django :: 1.10",
+        "Framework :: Django :: 1.11",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         'Programming Language :: Python :: 3',

--- a/simple_history/management/commands/populate_history.py
+++ b/simple_history/management/commands/populate_history.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
         else:
             try:
                 model = get_model(app_label, model)
-            except LookupError:  # Django >= 1.7
+            except LookupError:
                 model = None
         if not model:
             raise ValueError(self.MODEL_NOT_FOUND +

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -124,13 +124,9 @@ class HistoricalRecords(object):
             # registered under different app
             attrs['__module__'] = self.module
         elif app_module != self.module:
-            try:
-                # Abuse an internal API because the app registry is loading.
-                app = apps.app_configs[model._meta.app_label]
-            except NameError:  # Django < 1.7
-                models_module = get_app(model._meta.app_label).__name__
-            else:
-                models_module = app.name
+            # Abuse an internal API because the app registry is loading.
+            app = apps.app_configs[model._meta.app_label]
+            models_module = app.name
             attrs['__module__'] = models_module
 
         fields = self.copy_fields(model)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py{27,34}-django17,
     py{27,34,35}-django18,
     py{27,34,35}-django19,
     py{27,34,35,36}-django110,
@@ -30,7 +29,6 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 [testenv]
 deps =
     coverage
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
Since support for all versions of Django<1.11 was dropped on April 1, 2018, going to remove support for all those versions and then add support for 2.0. This is the first step in doing that. 