### PR TITLE
Added has_change_permission check to SimpleHistoryAdmin.history_view

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Authors
 - Kevin Foster
 - Shane Engelman
 - Ray Logel
+- Nathan Villagaray-Carski
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+----------
+- Fix bug where history_view ignored user permissions
+
 1.9.1 (2018-03-30)
 ------------------
 - Use get_queryset rather than model.objects in history_view. (gh-303)

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -63,6 +63,10 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
                 obj = action_list.latest('history_date').instance
             except action_list.model.DoesNotExist:
                 raise http.Http404
+
+        if not self.has_change_permission(request, obj):
+            raise PermissionDenied
+
         content_type = ContentType.objects.get_by_natural_key(
             *USER_NATURAL_KEY)
         admin_user_view = 'admin:%s_%s_change' % (content_type.app_label,

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -92,6 +92,11 @@ class AdminSiteTest(WebTest):
         self.assertIn("12", response.unicode_normal_body)
         self.assertIn("15", response.unicode_normal_body)
 
+    def test_history_view_permission(self):
+        self.login()
+        person = Person.objects.create(name='Sandra Hale')
+        self.app.get(get_history_url(person), status=403)
+
     def test_history_form_permission(self):
         self.login(self.user)
         person = Person.objects.create(name='Sandra Hale')


### PR DESCRIPTION
`SimpleHistoryAdmin.history_view` did not check user permissions, meaning that any staff user could view the history of any object using `SimpleHistoryAdmin`. This PR raises `PermissionDenied` when `has_change_permission` returns False.