### PR TITLE
More Django 1.9 leftovers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,6 +34,7 @@ Authors
 - Marty Alchin
 - Mauricio de Abreu Antunes
 - Micah Denbraver
+- Phillip Marshall
 - Rajesh Pappula
 - Roberto Aguilar
 - Rod Xavier Bondoc

--- a/runtests.py
+++ b/runtests.py
@@ -39,7 +39,7 @@ DEFAULT_SETTINGS = dict(
             'ENGINE': 'django.db.backends.sqlite3',
         }
     },
-    MIDDLEWARE_CLASSES=[
+    MIDDLEWARE=[
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -8,8 +8,8 @@ from django.contrib.admin import helpers
 from django.contrib.admin.utils import unquote
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 from django.utils.encoding import force_text
 from django.utils.html import mark_safe
 from django.utils.text import capfirst

--- a/simple_history/middleware.py
+++ b/simple_history/middleware.py
@@ -1,9 +1,9 @@
-from django.utils.deprecation import MiddlewareMixin as MiddlewareBase
+from django.utils.deprecation import MiddlewareMixin
 
 from .models import HistoricalRecords
 
 
-class HistoryRequestMiddleware(MiddlewareBase):
+class HistoryRequestMiddleware(MiddlewareMixin):
     """Expose request to HistoricalRecords.
 
     This middleware sets request as a local thread variable, making it

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.db import models, router
 from django.db.models.fields.proxy import OrderWrt
+from django.urls import reverse
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.timezone import now
@@ -206,14 +207,13 @@ class HistoricalRecords(object):
 
         user_model = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
-        @models.permalink
         def revert_url(self):
             """URL for this change in the default admin site."""
             opts = model._meta
             app_label, model_name = opts.app_label, opts.model_name
-            return ('%s:%s_%s_simple_history' %
+            return reverse('%s:%s_%s_simple_history' %
                     (admin.site.name, app_label, model_name),
-                    [getattr(self, opts.pk.attname), self.history_id])
+                    args=[getattr(self, opts.pk.attname), self.history_id])
 
         def get_instance(self):
             return model(**{

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -198,8 +198,8 @@ class AdminSiteTest(WebTest):
 
     def test_middleware_saves_user(self):
         overridden_settings = {
-            'MIDDLEWARE_CLASSES':
-                settings.MIDDLEWARE_CLASSES +
+            'MIDDLEWARE':
+                settings.MIDDLEWARE +
                 ['simple_history.middleware.HistoryRequestMiddleware'],
         }
         with override_settings(**overridden_settings):
@@ -216,8 +216,8 @@ class AdminSiteTest(WebTest):
 
     def test_middleware_unsets_request(self):
         overridden_settings = {
-            'MIDDLEWARE_CLASSES':
-                settings.MIDDLEWARE_CLASSES +
+            'MIDDLEWARE':
+                settings.MIDDLEWARE +
                 ['simple_history.middleware.HistoryRequestMiddleware'],
         }
         with override_settings(**overridden_settings):
@@ -231,8 +231,8 @@ class AdminSiteTest(WebTest):
         # creating a new entry does not fail with a foreign key error.
 
         overridden_settings = {
-            'MIDDLEWARE_CLASSES':
-                settings.MIDDLEWARE_CLASSES +
+            'MIDDLEWARE':
+                settings.MIDDLEWARE +
                 ['simple_history.middleware.HistoryRequestMiddleware'],
         }
         with override_settings(**overridden_settings):
@@ -253,8 +253,8 @@ class AdminSiteTest(WebTest):
 
     def test_middleware_anonymous_user(self):
         overridden_settings = {
-            'MIDDLEWARE_CLASSES':
-                settings.MIDDLEWARE_CLASSES +
+            'MIDDLEWARE':
+                settings.MIDDLEWARE +
                 ['simple_history.middleware.HistoryRequestMiddleware'],
         }
         with override_settings(**overridden_settings):

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -5,9 +5,9 @@ from django.contrib.admin import AdminSite
 from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils.encoding import force_text
 from django_webtest import WebTest
 from mock import ANY, patch


### PR DESCRIPTION
Follow up to #362 

- Removed a pointless MiddlewareMixin alias in simple_history/middleware.py that was part of an old compatibility shim.
- Tests now use the MIDDLEWARE setting rather than MIDDLEWARE_CLASSES. This isn't required until Django 2.0, but now that 1.9 is dropped I see no reason not to switch over now.
- Import reverse() from django.urls rather than deprecated django.core.urlresolvers module.
- Removed usage of django's deprecated @models.permalink decorator. (Deprecated in 1.11, but the fix might as well be done now.)

Thanks :)