### PR TITLE
Removed reference to south package.

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -19,14 +19,6 @@ from django.utils.translation import ugettext_lazy as _
 from . import exceptions
 from .manager import HistoryDescriptor
 
-try:
-    from south.modelsinspector import add_introspection_rules
-except ImportError:  # south not present
-    pass
-else:  # south configuration for CustomForeignKeyField
-    add_introspection_rules(
-        [], ["^simple_history.models.CustomForeignKeyField"])
-
 registered_models = {}
 
 


### PR DESCRIPTION
South isn't compatible with Django 1.7 or higher, and we require 1.11. There's no scenario where this try block can do anything but pass. Let's get rid of it.