### PR TITLE
Don't populate excluded fields while populating existing models history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,7 +60,8 @@ Authors
 - Nathan Villagaray-Carski
 - Mike Spainhower
 - Alexander Anikeev
-- Kyle Seever
+- Adnan Umer (@uadnan)
+- Jonathan Zvesper (@zvesp)
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,16 @@
 Changes
 =======
 
+Unreleased
+----------
+- Fix TypeError on populate_history if excluded_fields are specified
+
 2.1.0 (2018-06-04)
 ------------------
 - Add ability to specify custom history_reason field (gh-379)
 - Add ability to specify custom history_id field (gh-368)
 - Add HistoricalRecord instance properties `prev_record` and `next_record` (gh-365)
 - Can set admin methods as attributes on object history change list template (gh-390)
-- Fixed compatibility of >= 2.0 versions with old-style middleware (gh-369)
 
 2.0 (2018-04-05)
 ----------------

--- a/simple_history/management/commands/_populate_utils.py
+++ b/simple_history/management/commands/_populate_utils.py
@@ -24,8 +24,7 @@ def bulk_history_create(model, history_model, batch_size):
             **{
                 field.attname: getattr(instance, field.attname)
                 for field in instance._meta.fields
-                if field.name not in history_model.excluded_fields or
-                   field.attname not in history_model.excluded_fields
+                if field.name not in history_model.excluded_fields
             }
         ) for instance in model.objects.all()]
     history_model.objects.bulk_create(historical_instances,

--- a/simple_history/management/commands/_populate_utils.py
+++ b/simple_history/management/commands/_populate_utils.py
@@ -24,7 +24,7 @@ def bulk_history_create(model, history_model, batch_size):
             **{
                 field.attname: getattr(instance, field.attname)
                 for field in instance._meta.fields
-                if field.name not in history_model.excluded_fields
+                if field.name not in history_model._history_excluded_fields
             }
         ) for instance in model.objects.all()]
     history_model.objects.bulk_create(historical_instances,

--- a/simple_history/management/commands/_populate_utils.py
+++ b/simple_history/management/commands/_populate_utils.py
@@ -24,6 +24,8 @@ def bulk_history_create(model, history_model, batch_size):
             **{
                 field.attname: getattr(instance, field.attname)
                 for field in instance._meta.fields
+                if field.name not in history_model.excluded_fields or
+                   field.attname not in history_model.excluded_fields
             }
         ) for instance in model.objects.all()]
     history_model.objects.bulk_create(historical_instances,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -228,10 +228,14 @@ class HistoricalRecords(object):
                 for field in fields.values()
             }
             if self.excluded_fields:
-                actual_model = self.instance_type.objects.get(pk=getattr(self, self.instance_type._meta.pk.attname))
-                for field in self.excluded_fields:
-                    attrs[field] = getattr(actual_model, field)
-
+                excluded_attnames = [
+                    model._meta.get_field(field).attname
+                    for field in self.excluded_fields
+                ]
+                values = model.objects.filter(
+                    pk=getattr(self, model._meta.pk.attname)
+                ).values(*excluded_attnames).get()
+                attrs.update(values)
             return model(**attrs)
 
         def get_next_record(self):

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -115,7 +115,7 @@ class HistoricalRecords(object):
         """
         attrs = {
             '__module__': self.module,
-            'excluded_fields': self.excluded_fields
+            '_history_excluded_fields': self.excluded_fields
         }
 
         app_module = '%s.models' % model._meta.app_label
@@ -227,10 +227,10 @@ class HistoricalRecords(object):
                 field.attname: getattr(self, field.attname)
                 for field in fields.values()
             }
-            if self.excluded_fields:
+            if self._history_excluded_fields:
                 excluded_attnames = [
                     model._meta.get_field(field).attname
-                    for field in self.excluded_fields
+                    for field in self._history_excluded_fields
                 ]
                 values = model.objects.filter(
                     pk=getattr(self, model._meta.pk.attname)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -32,6 +32,14 @@ class PollWithExcludeFields(models.Model):
     history = HistoricalRecords(excluded_fields=['pub_date'])
 
 
+class PollWithExcludedFKField(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField('date published')
+    place = models.ForeignKey('Place')
+
+    history = HistoricalRecords(excluded_fields=['place'])
+
+
 class Temperature(models.Model):
     location = models.CharField(max_length=200)
     temperature = models.IntegerField()

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -35,7 +35,7 @@ class PollWithExcludeFields(models.Model):
 class PollWithExcludedFKField(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField('date published')
-    place = models.ForeignKey('Place')
+    place = models.ForeignKey('Place', on_delete=models.CASCADE)
 
     history = HistoricalRecords(excluded_fields=['place'])
 

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -120,5 +120,3 @@ class TestPopulateHistory(TestCase):
                                 'tests.pollwithexcludefields', auto=True)
         update_record = models.PollWithExcludeFields.history.all()[0]
         self.assertEqual(update_record.question, poll.question)
-        with self.assertRaises(AttributeError):
-            update_record.pub_date

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -111,3 +111,14 @@ class TestPopulateHistory(TestCase):
                                     stdout=out)
         self.assertIn(populate_history.Command.NO_REGISTERED_MODELS,
                       out.getvalue())
+
+    def test_excluded_fields(self):
+        poll = models.PollWithExcludeFields.objects.create(
+            question="Will this work?", pub_date=datetime.now())
+        models.PollWithExcludeFields.history.all().delete()
+        management.call_command(self.command_name,
+                                'tests.pollwithexcludefields', auto=True)
+        update_record = models.PollWithExcludeFields.history.all()[0]
+        self.assertEqual(update_record.question, poll.question)
+        with self.assertRaises(AttributeError):
+            update_record.pub_date

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -118,5 +118,5 @@ class TestPopulateHistory(TestCase):
         models.PollWithExcludeFields.history.all().delete()
         management.call_command(self.command_name,
                                 'tests.pollwithexcludefields', auto=True)
-        update_record = models.PollWithExcludeFields.history.all()[0]
-        self.assertEqual(update_record.question, poll.question)
+        initial_history_record = models.PollWithExcludeFields.history.all()[0]
+        self.assertEqual(initial_history_record.question, poll.question)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -985,7 +985,7 @@ class ExcludeForeignKeyTest(TestCase):
             historical.place
 
     def test_nb_queries(self):
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             historical = self.get_first_historical()
             historical.instance
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -40,9 +40,11 @@ from ..models import (
     Library,
     MultiOneToOne,
     Person,
+    Place,
     Poll,
     PollInfo,
     PollWithExcludeFields,
+    PollWithExcludedFKField,
     Province,
     Restaurant,
     SelfFK,
@@ -953,5 +955,44 @@ class ExcludeFieldsTest(TestCase):
         poll = PollWithExcludeFields.objects.create(question="what's up?",
                                                     pub_date=today)
         historical = poll.history.order_by('pk')[0]
+        with self.assertRaises(AttributeError):
+            historical.pub_date
         original = historical.instance
         self.assertEqual(original.pub_date, poll.pub_date)
+
+
+class ExcludeForeignKeyTest(TestCase):
+    def setUp(self):
+        self.poll = PollWithExcludedFKField.objects.create(
+            question="Is it?", pub_date=today,
+            place=Place.objects.create(name="Somewhere")
+        )
+
+    def get_first_historical(self):
+        """
+        Retrieve the idx'th HistoricalPoll, ordered by time.
+        """
+        return self.poll.history.order_by('history_date')[0]
+
+    def test_instance_fk_value(self):
+        historical = self.get_first_historical()
+        original = historical.instance
+        self.assertEqual(original.place, self.poll.place)
+
+    def test_history_lacks_fk(self):
+        historical = self.get_first_historical()
+        with self.assertRaises(AttributeError):
+            historical.place
+
+    def test_nb_queries(self):
+        with self.assertNumQueries(3):
+            historical = self.get_first_historical()
+            historical.instance
+
+    def test_changed_value_lost(self):
+        new_place = Place.objects.create(name="More precise")
+        self.poll.place = new_place
+        self.poll.save()
+        historical = self.get_first_historical()
+        instance = historical.instance
+        self.assertEqual(instance.place, new_place)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -946,3 +946,12 @@ class CustomTableNameTest1(TestCase):
             self.get_table_name(ContactRegister.history),
             'contacts_register_history',
         )
+
+
+class ExcludeFieldsTest(TestCase):
+    def test_restore_pollwithexclude(self):
+        poll = PollWithExcludeFields.objects.create(question="what's up?",
+                                                    pub_date=today)
+        historical = poll.history.order_by('pk')[0]
+        original = historical.instance
+        self.assertEqual(original.pub_date, poll.pub_date)


### PR DESCRIPTION
Consider existing model, on which `HistoricalRecords` is added with some fields excluded,

```
 class MyModel(models.Model):
    name = models.CharField(max_length=100)
    created = models.DateTimeField(auto_now_add=True)
    modified = models.DateTimeField(auto_now=True)

    history = HistoricalRecords(excluded_fields=['created', 'modified'])
```

And here in this case, `populate_history`  will still try to instantiate the model with `created` and `modified` value, that leads to this error:

```
TypeError: 'created' is an invalid keyword argument for this function
```

This pull request address above described issue and replaces #304