### PR TITLE
Evaluate method returned from getattribute, if it is callable

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -61,6 +61,12 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         if not self.has_change_permission(request, obj):
             raise PermissionDenied
 
+        # Set attribute from admin methods, if present
+        for x in history_list_display:
+            if getattr(self, x, None) and type(getattr(self, x)) == MethodType:
+                history_method = getattr(self, x)
+                setattr(obj, x, history_method(obj))
+
         content_type = ContentType.objects.get_by_natural_key(
             *USER_NATURAL_KEY)
         admin_user_view = 'admin:%s_%s_change' % (content_type.app_label,


### PR DESCRIPTION
Currently, if you have a method defined in history_list_display, None is returned as the method isn't evaluated from getattribute.

This should allow folks to define methods in their attribute lists for history.