### PR TITLE
Backward compatible middleware

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -59,6 +59,7 @@ Authors
 - Ray Logel
 - Nathan Villagaray-Carski
 - Mike Spainhower
+- Alexander Anikeev
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Add ability to specify custom history_id field (gh-368)
 - Add HistoricalRecord instance properties `prev_record` and `next_record` (gh-365)
 - Can set admin methods as attributes on object history change list template (gh-390)
+- Fixed compatibility of >= 2.0 versions with old-style middleware (gh-369)
 
 2.0 (2018-04-05)
 ----------------

--- a/runtests.py
+++ b/runtests.py
@@ -39,7 +39,9 @@ DEFAULT_SETTINGS = dict(
             'ENGINE': 'django.db.backends.sqlite3',
         }
     },
-    MIDDLEWARE=[
+    # Use old-style middleware by default, because otherwise
+    # Its unclear how to override settings
+    MIDDLEWARE_CLASSES=[
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',

--- a/runtests.py
+++ b/runtests.py
@@ -39,14 +39,6 @@ DEFAULT_SETTINGS = dict(
             'ENGINE': 'django.db.backends.sqlite3',
         }
     },
-    # By default django uses new-style middleware, and falls back to old,
-    # if `MIDDLEWARE` is not set. So we use old style by default in order to
-    # be able to test both. New-style middleware tests just set `MIDDLEWARE`
-    MIDDLEWARE_CLASSES=[
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-    ],
     TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
@@ -57,6 +49,16 @@ DEFAULT_SETTINGS = dict(
         },
     }],
 )
+MIDDLEWARE = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+if django.__version__ >= '2.0':
+    DEFAULT_SETTINGS['MIDDLEWARE'] = MIDDLEWARE
+else:
+    DEFAULT_SETTINGS['MIDDLEWARE_CLASSES'] = MIDDLEWARE
 
 
 def main():

--- a/runtests.py
+++ b/runtests.py
@@ -39,8 +39,9 @@ DEFAULT_SETTINGS = dict(
             'ENGINE': 'django.db.backends.sqlite3',
         }
     },
-    # Use old-style middleware by default, because otherwise
-    # Its unclear how to override settings
+    # By default django uses new-style middleware, and falls back to old,
+    # if `MIDDLEWARE` is not set. So we use old style by default in order to
+    # be able to test both. New-style middleware tests just set `MIDDLEWARE`
     MIDDLEWARE_CLASSES=[
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/simple_history/middleware.py
+++ b/simple_history/middleware.py
@@ -1,7 +1,9 @@
+from django.utils.deprecation import MiddlewareMixin
+
 from .models import HistoricalRecords
 
 
-class HistoryRequestMiddleware:
+class HistoryRequestMiddleware(MiddlewareMixin):
     """Expose request to HistoricalRecords.
 
     This middleware sets request as a local thread variable, making it
@@ -9,21 +11,10 @@ class HistoryRequestMiddleware:
     authenticated user making a change.
     """
 
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        # Code to be executed for each request before
-        # the view (and later middleware) are called.
-
+    def process_request(self, request):
         HistoricalRecords.thread.request = request
 
-        response = self.get_response(request)
-
-        # Code to be executed for each request/response after
-        # the view is called.
-
+    def process_response(self, request, response):
         if hasattr(HistoricalRecords.thread, 'request'):
             del HistoricalRecords.thread.request
-
         return response

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -46,8 +46,9 @@ def get_history_url(obj, history_index=None, site="admin"):
 
 
 overridden_settings = {
-    'MIDDLEWARE': (settings.MIDDLEWARE +
-                   ['simple_history.middleware.HistoryRequestMiddleware']),
+    'MIDDLEWARE_CLASSES': (
+        settings.MIDDLEWARE_CLASSES +
+        ['simple_history.middleware.HistoryRequestMiddleware']),
 }
 
 

--- a/simple_history/tests/tests/test_middleware.py
+++ b/simple_history/tests/tests/test_middleware.py
@@ -1,25 +1,15 @@
 from datetime import date
 
-from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from simple_history.tests.custom_user.models import CustomUser
 from simple_history.tests.models import Poll
-
-new_style_middleware_settings = {
-    'MIDDLEWARE': (settings.MIDDLEWARE_CLASSES +
-                   ['simple_history.middleware.HistoryRequestMiddleware']),
-}
-old_style_middleware_settings = {
-    'MIDDLEWARE_CLASSES': (
-        settings.MIDDLEWARE_CLASSES +
-        ['simple_history.middleware.HistoryRequestMiddleware']),
-}
+from simple_history.tests.tests.utils import middleware_override_settings
 
 
-@override_settings(**new_style_middleware_settings)
-class NewMiddlewareTest(TestCase):
+@override_settings(**middleware_override_settings)
+class MiddlewareTest(TestCase):
     def setUp(self):
         self.user = CustomUser.objects.create_superuser(
             'user_login',
@@ -170,8 +160,3 @@ class NewMiddlewareTest(TestCase):
 
         self.assertListEqual([ph.history_user_id for ph in poll_history],
                              [None, None])
-
-
-@override_settings(**old_style_middleware_settings)
-class OldMiddlewareTest(NewMiddlewareTest):
-    pass

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -1,0 +1,17 @@
+import django
+from django.conf import settings
+
+simple_history_middleware = 'simple_history.middleware.HistoryRequestMiddleware'
+
+if django.__version__ >= '2.0':
+    middleware_override_settings = {
+        'MIDDLEWARE': (
+            settings.MIDDLEWARE + [simple_history_middleware]
+        )
+    }
+else:
+    middleware_override_settings = {
+        'MIDDLEWARE_CLASSES': (
+            settings.MIDDLEWARE_CLASSES + [simple_history_middleware]
+        )
+    }

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -1,17 +1,17 @@
 import django
 from django.conf import settings
 
-simple_history_middleware = 'simple_history.middleware.HistoryRequestMiddleware'
+request_middleware = 'simple_history.middleware.HistoryRequestMiddleware'
 
 if django.__version__ >= '2.0':
     middleware_override_settings = {
         'MIDDLEWARE': (
-            settings.MIDDLEWARE + [simple_history_middleware]
+            settings.MIDDLEWARE + [request_middleware]
         )
     }
 else:
     middleware_override_settings = {
         'MIDDLEWARE_CLASSES': (
-            settings.MIDDLEWARE_CLASSES + [simple_history_middleware]
+            settings.MIDDLEWARE_CLASSES + [request_middleware]
         )
     }


### PR DESCRIPTION
## Description
Return to usage of `django.utils.deprecation.MiddlewareMixin`.

## Related Issue
Steps to reproduce:

1. Use old middleware setting (MIDDLEWARE_CLASSES)
2. Use django-simple-history 2.0

Issue: https://github.com/treyhunner/django-simple-history/issues/369

## Motivation and Context
Support projects with old middleware.

## How Has This Been Tested?
Used old-style middleware in tests for Django < 2.0, and new-style for others

## Screenshots (if appropriate):

## Types of changes
Backward compatibility

## Checklist:
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
