### PR TITLE
GH-380: Save history on bulk_create

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changes
 
 Unreleased
 ----------
-- Add ability to specify alternative user_model for tracking
+- Add ability to specify alternative user_model for tracking (gh-371)
+- Add util function ``bulk_create_with_history`` to allow bulk_create with history saved
 
 2.1.1 (2018-06-15)
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -312,13 +312,17 @@ This will change the ``poll`` instance to have the data from the
 ``HistoricalPoll`` object and it will create a new row in the
 ``HistoricalPoll`` table indicating that a new change has been made.
 
-Bulk Creating a Model with History
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Bulk Creating and Queryset Updating
+-----------------------------------
 Django Simple History functions by saving history using a ``post_save`` signal
 every time that an object with history is saved. However, for certain bulk
 operations, such as bulk_create_ and `queryset updates <https://docs.djangoproject.com/en/2.0/ref/models/querysets/#update>`_,
-signals are not sent, and the history is not saved automatically. As of
-Django Simple History 2.2.0, we can use the utility function
+signals are not sent, and the history is not saved automatically. However,
+Django Simple History provides utility functions to work around this.
+
+Bulk Creating a Model with History
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ As of Django Simple History 2.2.0, we can use the utility function
 ``bulk_create_with_history`` in order to bulk create objects while saving their
 history:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -311,3 +311,29 @@ And to revert to that ``HistoricalPoll`` instance, we can do:
 This will change the ``poll`` instance to have the data from the
 ``HistoricalPoll`` object and it will create a new row in the
 ``HistoricalPoll`` table indicating that a new change has been made.
+
+Bulk Creating a Model with History
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Django Simple History functions by saving history using a ``post_save`` signal
+every time that an object with history is saved. However, for certain bulk
+operations, such as bulk_create_ and `queryset updates<https://docs.djangoproject.com/en/2.0/ref/models/querysets/#update>`_,
+signals are not sent, and the history is not saved automatically. As of
+Django Simple History 2.2.0, we can use the utility function
+``bulk_create_with_history`` in order to bulk create objects while saving their
+history:
+
+.. _bulk_create: https://docs.djangoproject.com/en/2.0/ref/models/querysets/#bulk-create
+
+
+.. code-block:: pycon
+
+    >>> from simple_history.utils import bulk_create_with_history
+    >>> from simple_history.tests.models import Poll
+    >>> from django.utils.timezone import now
+    >>>
+    >>> data = [Poll(id=x, question='Question ' + str(x), pub_date=now()) for x in range(1000)]
+    >>> objs = bulk_create_with_history(data, Poll, batch_size=500)
+    >>> Poll.objects.count()
+    1000
+    >>> Poll.history.count()
+    1000

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -316,7 +316,7 @@ Bulk Creating a Model with History
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Django Simple History functions by saving history using a ``post_save`` signal
 every time that an object with history is saved. However, for certain bulk
-operations, such as bulk_create_ and `queryset updates<https://docs.djangoproject.com/en/2.0/ref/models/querysets/#update>`_,
+operations, such as bulk_create_ and `queryset updates <https://docs.djangoproject.com/en/2.0/ref/models/querysets/#update>`_,
 signals are not sent, and the history is not saved automatically. As of
 Django Simple History 2.2.0, we can use the utility function
 ``bulk_create_with_history`` in order to bulk create objects while saving their

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -1,0 +1,106 @@
+from django.db import IntegrityError
+from django.test import TestCase, TransactionTestCase
+from django.utils.timezone import now
+from mock import Mock, patch
+
+from simple_history.exceptions import NotHistoricalModelError
+from simple_history.tests.models import Place, Poll, Document, PollWithExcludeFields
+from simple_history.utils import bulk_create_with_history
+
+
+class BulkCreateWithHistoryTestCase(TestCase):
+    def setUp(self):
+        self.data = [
+            Poll(id=1, question='Question 1', pub_date=now()),
+            Poll(id=2, question='Question 2', pub_date=now()),
+            Poll(id=3, question='Question 3', pub_date=now()),
+            Poll(id=4, question='Question 4', pub_date=now()),
+            Poll(id=5, question='Question 5', pub_date=now()),
+        ]
+
+    def test_bulk_create_history(self):
+        bulk_create_with_history(self.data, Poll)
+
+        self.assertEqual(Poll.objects.count(), 5)
+        self.assertEqual(Poll.history.count(), 5)
+
+    def test_bulk_create_history_num_queries_is_two(self):
+        with self.assertNumQueries(2):
+            bulk_create_with_history(self.data, Poll)
+
+    def test_bulk_create_history_on_model_without_history_raises_error(self):
+        self.data = [
+            Place(id=1, name='Place 1'),
+            Place(id=2, name='Place 2'),
+            Place(id=3, name='Place 3'),
+        ]
+        with self.assertRaises(NotHistoricalModelError):
+            bulk_create_with_history(self.data, Place)
+
+    def test_num_queries_when_batch_size_is_less_than_total(self):
+        with self.assertNumQueries(6):
+            bulk_create_with_history(self.data, Poll, batch_size=2)
+
+    def test_bulk_create_history_with_batch_size(self):
+        bulk_create_with_history(self.data, Poll, batch_size=2)
+
+        self.assertEqual(Poll.objects.count(), 5)
+        self.assertEqual(Poll.history.count(), 5)
+
+    def test_bulk_create_works_with_excluded_fields(self):
+        bulk_create_with_history(self.data, PollWithExcludeFields)
+
+        self.assertEqual(Poll.objects.count(), 0)
+        self.assertEqual(Poll.history.count(), 0)
+
+        self.assertEqual(PollWithExcludeFields.objects.count(), 5)
+        self.assertEqual(PollWithExcludeFields.history.count(), 5)
+
+
+class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
+    def setUp(self):
+        self.data = [
+            Poll(id=1, question='Question 1', pub_date=now()),
+            Poll(id=2, question='Question 2', pub_date=now()),
+            Poll(id=3, question='Question 3', pub_date=now()),
+            Poll(id=4, question='Question 4', pub_date=now()),
+            Poll(id=5, question='Question 5', pub_date=now()),
+        ]
+
+    @patch('simple_history.manager.HistoryManager.bulk_history_create',
+           Mock(side_effect=Exception))
+    def test_transaction_rolls_back_if_bulk_history_create_fails(self):
+        with self.assertRaises(Exception):
+            bulk_create_with_history(self.data, Poll)
+
+        self.assertEqual(Poll.objects.count(), 0)
+        self.assertEqual(Poll.history.count(), 0)
+
+    def test_bulk_create_history_on_objects_that_already_exist(self):
+        Poll.objects.bulk_create(self.data)
+
+        with self.assertRaises(IntegrityError):
+            bulk_create_with_history(self.data, Poll)
+
+        self.assertEqual(Poll.objects.count(), 5)
+        self.assertEqual(Poll.history.count(), 0)
+
+    def test_bulk_create_history_rolls_back_when_last_batch_already_exists(self):
+        Poll.objects.create(id=5, question='Question 5', pub_date=now())
+
+        self.assertEqual(Poll.objects.count(), 1)
+        self.assertEqual(Poll.history.count(), 1)
+
+        with self.assertRaises(IntegrityError):
+            bulk_create_with_history(self.data, Poll, batch_size=1)
+
+        self.assertEqual(Poll.objects.count(), 1)
+        self.assertEqual(Poll.history.count(), 1)
+
+    def test_bulk_create_fails_with_wrong_model(self):
+        with self.assertRaises(AttributeError):
+            bulk_create_with_history(self.data, Document)
+
+        self.assertEqual(Poll.objects.count(), 0)
+        self.assertEqual(Poll.history.count(), 0)
+

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -4,7 +4,12 @@ from django.utils.timezone import now
 from mock import Mock, patch
 
 from simple_history.exceptions import NotHistoricalModelError
-from simple_history.tests.models import Place, Poll, Document, PollWithExcludeFields
+from simple_history.tests.models import (
+    Document,
+    Place,
+    Poll,
+    PollWithExcludeFields
+)
 from simple_history.utils import bulk_create_with_history
 
 
@@ -85,7 +90,7 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         self.assertEqual(Poll.objects.count(), 5)
         self.assertEqual(Poll.history.count(), 0)
 
-    def test_bulk_create_history_rolls_back_when_last_batch_already_exists(self):
+    def test_bulk_create_history_rolls_back_when_last_exists(self):
         Poll.objects.create(id=5, question='Question 5', pub_date=now())
 
         self.assertEqual(Poll.objects.count(), 1)
@@ -103,4 +108,3 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
 
         self.assertEqual(Poll.objects.count(), 0)
         self.assertEqual(Poll.history.count(), 0)
-

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -39,6 +39,10 @@ def bulk_create_with_history(objs, model, batch_size=None):
     """
     Bulk create the objects specified by objs while also bulk creating
     their history (all in one transaction).
+    :param objs: List of objs (not yet saved to the db) of type model
+    :param model: Model class that should be created
+    :param batch_size: Number of objects that should be created in each batch
+    :return: List of objs with IDs
     """
 
     history_manager = get_history_manager_for_model(model)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows users to call `bulk_create_with_history` on objects, and both the objects and the historical objects will be created with `bulk_create`.
## Description
<!--- Describe your changes in detail -->
 Created `bulk_create_with_history` utility function to allow users to bulk_create objects while maintaining their history. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #380. Updates documentation for #174. Follow-on PR will add util function to `update` with history as well. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Django Simple History works by catching `post_save` signals in order to write to the history table. Since `post_save` signals are not sent when calling a manager's `bulk_create` method, `bulk_create` will create a bunch of objects without creating the accompanying history. To solve this, I created a utility function called `bulk_create_with_history`. It bulk_creates the normal objects and also bulk_creates the historical objects. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
