### PR TITLE
Implement the ability to diff HistoricalRecords

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,6 +35,7 @@ Authors
 - Kris Neuharth
 - Maciej "RooTer" Urbański
 - Mark Davidoff
+- Leticia Portella
 - Martin Bachwerk
 - Marty Alchin
 - Mauricio de Abreu Antunes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+-----------------
+- Add ability to diff HistoricalRecords (gh-244)
+
 2.2.0 (2018-07-02)
 ------------------
 - Add ability to specify alternative user_model for tracking (gh-371)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -412,9 +412,11 @@ History Diffing
 
 When you have two instances of the same ``HistoricalRecord`` (such as the ``HistoricalPoll`` example above),
 you can perform diffs to see what changed. This will result in a ``ModelDelta`` containing the following properties:
- 1. A list with each field changed between the two historical records
- 2. A list with the names of all fields that incurred changes from one record to the other
- 3. the old and new records.
+
+1. A list with each field changed between the two historical records
+2. A list with the names of all fields that incurred changes from one record to the other
+3. the old and new records.
+
 This may be useful when you want to construct timelines and need to get only the model modifications.
 
 .. code-block:: python

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -406,3 +406,21 @@ If you want to save a model without a historical record, you can use the followi
 
     poll = Poll(question='something')
     poll.save_without_historical_record()
+
+History Diffing
+-------------------
+
+When you have two instances of the same HistoricalRecord, such as HistoricalPoll example above,
+you can perform diffs to see what changed. This will result in a ModelDelta containing some properties such as a
+list with each field changed between this historical records, a list with the names of all
+fields that incurred changes from one record to another, and the old and new records.
+This may be useful when you want timelines, and need to get only the model modifications.
+
+.. code-block:: python
+
+    p = Poll.objects.create(question="what's up?")
+    p.question = "what's up, man?"
+    p.save()
+
+    new_record, old_record = p.history.all()
+    delta = new_record.diff_against(old_record)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -412,9 +412,9 @@ History Diffing
 
 When you have two instances of the same ``HistoricalRecord`` (such as the ``HistoricalPoll`` example above),
 you can perform diffs to see what changed. This will result in a ``ModelDelta`` containing the following properties:
-1. A list with each field changed between the two historical records
-2. A list with the names of all fields that incurred changes from one record to the other
-3. the old and new records.
+ 1. A list with each field changed between the two historical records
+ 2. A list with the names of all fields that incurred changes from one record to the other
+ 3. the old and new records.
 This may be useful when you want to construct timelines and need to get only the model modifications.
 
 .. code-block:: python

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -412,9 +412,9 @@ History Diffing
 
 When you have two instances of the same ``HistoricalRecord`` (such as the ``HistoricalPoll`` example above),
 you can perform diffs to see what changed. This will result in a ``ModelDelta`` containing the following properties:
- 1. A list with each field changed between the two historical records
- 2. A list with the names of all fields that incurred changes from one record to the other
- 3. the old and new records.
+1. A list with each field changed between the two historical records
+2. A list with the names of all fields that incurred changes from one record to the other
+3. the old and new records.
 This may be useful when you want to construct timelines and need to get only the model modifications.
 
 .. code-block:: python

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -410,11 +410,11 @@ If you want to save a model without a historical record, you can use the followi
 History Diffing
 -------------------
 
-When you have two instances of the same HistoricalRecord, such as HistoricalPoll example above,
-you can perform diffs to see what changed. This will result in a ModelDelta containing some properties such as a
-list with each field changed between this historical records, a list with the names of all
-fields that incurred changes from one record to another, and the old and new records.
-This may be useful when you want timelines, and need to get only the model modifications.
+When you have two instances of the same HistoricalRecord (such as the HistoricalPoll example above),
+you can perform diffs to see what changed. This will result in a ModelDelta containing properties including
+a list with each field changed between the two historical records, a list with the names of all
+fields that incurred changes from one record to the other, and the old and new records.
+This may be useful when you want to construct timelines and need to get only the model modifications.
 
 .. code-block:: python
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -410,10 +410,11 @@ If you want to save a model without a historical record, you can use the followi
 History Diffing
 -------------------
 
-When you have two instances of the same HistoricalRecord (such as the HistoricalPoll example above),
-you can perform diffs to see what changed. This will result in a ModelDelta containing properties including
-a list with each field changed between the two historical records, a list with the names of all
-fields that incurred changes from one record to the other, and the old and new records.
+When you have two instances of the same ``HistoricalRecord`` (such as the ``HistoricalPoll`` example above),
+you can perform diffs to see what changed. This will result in a ``ModelDelta`` containing the following properties:
+ 1. A list with each field changed between the two historical records
+ 2. A list with the names of all fields that incurred changes from one record to the other
+ 3. the old and new records.
 This may be useful when you want to construct timelines and need to get only the model modifications.
 
 .. code-block:: python
@@ -424,3 +425,5 @@ This may be useful when you want to construct timelines and need to get only the
 
     new_record, old_record = p.history.all()
     delta = new_record.diff_against(old_record)
+    for change in delta.changes:
+        print("{} changed from {} to {}".format(change.field, change.old, change.new))

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -430,7 +430,8 @@ class HistoricalChanges(object):
                 old_value = getattr(old_history, field.name, '')
                 new_value = getattr(self, field.name)
                 if old_value != new_value:
-                    changes.append(ModelChange(field.name, old_value, new_value))
+                    change = ModelChange(field.name, old_value, new_value)
+                    changes.append(change)
                     changed_fields.append(field.name)
 
         return ModelDelta(changes,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -417,7 +417,7 @@ class HistoricalObjectDescriptor(object):
 class HistoricalChanges(object):
     def diff_against(self, old_history):
         if not isinstance(old_history, type(self)):
-            raise TypeError(("unsupported operand type(s) for diffing: "
+            raise TypeError(("unsupported type(s) for diffing: "
                              "'{}' and '{}'").format(
                             type(self),
                             type(old_history)))

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -53,7 +53,7 @@ class HistoricalRecords(object):
         try:
             if isinstance(bases, six.string_types):
                 raise TypeError
-            self.bases = tuple(bases)
+            self.bases = (HistoricalChanges,) + tuple(bases)
         except TypeError:
             raise TypeError("The `bases` option must be a list or a tuple.")
 
@@ -412,3 +412,44 @@ class HistoricalObjectDescriptor(object):
         values = (getattr(instance, f.attname)
                   for f in self.fields_included)
         return self.model(*values)
+
+
+class HistoricalChanges(object):
+    def diff_against(self, old_history):
+        if not isinstance(old_history, type(self)):
+            raise TypeError(("unsupported operand type(s) for diffing: "
+                             "'{}' and '{}'").format(
+                            type(self),
+                            type(old_history)))
+
+        model_delta_class = getattr(self, 'model_delta_class', ModelDelta)
+        changes = []
+        changed_fields = []
+        for field in self._meta.fields:
+            if hasattr(self.instance, field.name) and \
+               hasattr(old_history.instance, field.name):
+                old_value = getattr(old_history, field.name, '')
+                new_value = getattr(self, field.name)
+                if old_value != new_value:
+                    changes.append(ModelChange(field.name, old_value, new_value))
+                    changed_fields.append(field.name)
+
+        return model_delta_class(changes,
+                                 changed_fields=changed_fields,
+                                 old_record=old_history,
+                                 new_record=self)
+
+
+class ModelChange(object):
+    def __init__(self, field_name, old_value, new_value):
+        self.field = field_name
+        self.old = old_value
+        self.new = new_value
+
+
+class ModelDelta(object):
+    def __init__(self, changes, changed_fields, old_record, new_record):
+        self.changes = changes
+        self.changed_fields = changed_fields
+        self.old_record = old_record
+        self.new_record = new_record

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -422,7 +422,6 @@ class HistoricalChanges(object):
                             type(self),
                             type(old_history)))
 
-        model_delta_class = getattr(self, 'model_delta_class', ModelDelta)
         changes = []
         changed_fields = []
         for field in self._meta.fields:
@@ -434,10 +433,10 @@ class HistoricalChanges(object):
                     changes.append(ModelChange(field.name, old_value, new_value))
                     changed_fields.append(field.name)
 
-        return model_delta_class(changes,
-                                 changed_fields=changed_fields,
-                                 old_record=old_history,
-                                 new_record=self)
+        return ModelDelta(changes,
+                          changed_fields,
+                          old_history,
+                          self)
 
 
 class ModelChange(object):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -560,8 +560,8 @@ class HistoricalRecordsTest(TestCase):
         new_record, old_record = p.history.all()
         delta = new_record.diff_against(old_record)
         expected_change = ModelChange("question",
-                                       "what's up?",
-                                       "what's up, man")
+                                      "what's up?",
+                                      "what's up, man")
         self.assertEqual(delta.changed_fields, ['question'])
         self.assertEqual(delta.old_record, old_record)
         self.assertEqual(delta.new_record, new_record)
@@ -581,7 +581,7 @@ class HistoricalRecordsTest(TestCase):
         p.save()
         new_record, old_record = p.history.all()
         with self.assertRaises(TypeError):
-            delta = new_record.diff_against('something')
+            new_record.diff_against('something')
 
 
 class CreateHistoryModelTests(unittest.TestCase):


### PR DESCRIPTION
## Description
This PR adds the ability to produce the difference between two HistoricalRecord instances. 

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/244

## Motivation and Context
This change allows users to construct timelines of changes for a given record.

## How Has This Been Tested?
Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

(Credit goes to leportella for the initial commit)