### PR TITLE
Document some register attributes

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -64,6 +64,23 @@ third-party apps you don't have control over.  Here's an example of using
 
     register(User)
 
+If you want to separate the migrations of the historical model from those of
+the third-party model itself you can pass a module as ``app`` attribute to
+``register``. For instance, if the migrations shall live in the migrations
+folder of the package you register the model in, you could do:
+
+.. code-block:: python
+
+    register(User, app=__package__)
+
+You can pass attributes of the ``HistoricalRecords`` model directly to ``register``:
+
+.. code-block:: python
+    
+    register(User, excluded_fields=['last_login']))
+
+For a complete list of the attributes you can pass to ``register`` we refer
+to the source code.
 
 Allow tracking to be inherited
 ---------------------------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -73,7 +73,7 @@ folder of the package you register the model in, you could do:
 
     register(User, app=__package__)
 
-You can pass attributes of the ``HistoricalRecords`` model directly to ``register``:
+You can pass attributes of ``HistoricalRecords`` directly to ``register``:
 
 .. code-block:: python
     


### PR DESCRIPTION
Addressing several attributes of `register` for use with third-party apps:
1. `app`
2. `excluded_fields`
3. Reference for other attributes

I needed this and searched for a clean solution (almost opened an issue) and was happy when I saw that it is implemented already. People should know that all these features exist! :)

I implemented it in my project and it works. I only changed the documetation. Therefore I assume that I don't have to write a test.