### PR TITLE
Add pre and post create_historical_record signals

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -65,6 +65,7 @@ Authors
 - Kyle Seever
 - Adnan Umer (@uadnan)
 - Jonathan Zvesper (@zvesp)
+- Matheus Cansian (@mscansian)
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+------------------
+- Add pre and post create_historical_record signals (gh-426)
+
 2.3.0 (2018-07-19)
 ------------------
 - Add ability to diff HistoricalRecords (gh-244)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -446,3 +446,23 @@ This may be useful when you want to construct timelines and need to get only the
     delta = new_record.diff_against(old_record)
     for change in delta.changes:
         print("{} changed from {} to {}".format(change.field, change.old, change.new))
+
+Using signals
+------------------------------------
+django-simple-history includes signals that helps you provide custom behaviour when saving a historical record. If you want to connect the signals you can do so using the following code:
+
+.. code-block:: python
+
+    from django.dispatch import receiver
+    from simple_history.signals import (
+        pre_create_historical_record,
+        post_create_historical_record
+    )
+
+    @receiver(pre_create_historical_record)
+    def pre_create_historical_record(sender, instance, **kwargs):
+        print("Sent before saving historical record")
+
+    @receiver(pre_create_historical_record)
+        def post_create_historical_record(sender, instance, history_instance, **kwargs):
+            print("Sent after saving historical record")

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -346,14 +346,14 @@ class HistoricalRecords(object):
         history_date = getattr(instance, '_history_date', now())
         history_user = self.get_history_user(instance)
         history_change_reason = getattr(instance, 'changeReason', None)
+        manager = getattr(instance, self.manager_name)
 
         pre_create_historical_record.send(
-            sender=self.__class__, instance=instance,
+            sender=manager.model.__class__, instance=instance,
             history_date=history_date, history_user=history_user,
             history_change_reason=history_change_reason,
         )
 
-        manager = getattr(instance, self.manager_name)
         attrs = {}
         for field in self.fields_included(instance):
             attrs[field.attname] = getattr(instance, field.attname)
@@ -364,7 +364,7 @@ class HistoricalRecords(object):
         )
 
         post_create_historical_record.send(
-            sender=self.__class__, instance=instance,
+            sender=manager.model.__class__, instance=instance,
             history_instance=history_instance,
             history_date=history_date, history_user=history_user,
             history_change_reason=history_change_reason,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -20,6 +20,10 @@ from django.utils.translation import ugettext_lazy as _
 
 from . import exceptions
 from .manager import HistoryDescriptor
+from .signals import (
+    pre_create_historical_record,
+    post_create_historical_record,
+)
 
 registered_models = {}
 
@@ -343,13 +347,28 @@ class HistoricalRecords(object):
         history_user = self.get_history_user(instance)
         history_change_reason = getattr(instance, 'changeReason', None)
 
+        pre_create_historical_record.send(
+            sender=self.__class__, instance=instance,
+            history_date=history_date, history_user=history_user,
+            history_change_reason=history_change_reason,
+        )
+
         manager = getattr(instance, self.manager_name)
         attrs = {}
         for field in self.fields_included(instance):
             attrs[field.attname] = getattr(instance, field.attname)
-        manager.create(history_date=history_date, history_type=history_type,
-                       history_user=history_user,
-                       history_change_reason=history_change_reason, **attrs)
+        history_instance = manager.create(
+            history_date=history_date, history_type=history_type,
+            history_user=history_user,
+            history_change_reason=history_change_reason, **attrs
+        )
+
+        post_create_historical_record.send(
+            sender=self.__class__, instance=instance,
+            history_instance=history_instance,
+            history_date=history_date, history_user=history_user,
+            history_change_reason=history_change_reason,
+        )
 
     def get_history_user(self, instance):
         """Get the modifying user from instance or middleware."""

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -349,7 +349,7 @@ class HistoricalRecords(object):
         manager = getattr(instance, self.manager_name)
 
         pre_create_historical_record.send(
-            sender=manager.model.__class__, instance=instance,
+            sender=manager.model, instance=instance,
             history_date=history_date, history_user=history_user,
             history_change_reason=history_change_reason,
         )
@@ -364,7 +364,7 @@ class HistoricalRecords(object):
         )
 
         post_create_historical_record.send(
-            sender=manager.model.__class__, instance=instance,
+            sender=manager.model, instance=instance,
             history_instance=history_instance,
             history_date=history_date, history_user=history_user,
             history_change_reason=history_change_reason,

--- a/simple_history/signals.py
+++ b/simple_history/signals.py
@@ -1,0 +1,10 @@
+import django.dispatch
+
+
+pre_create_historical_record = django.dispatch.Signal(providing_args=[
+    'instance', 'history_date', 'history_user', 'history_change_reason',
+])
+post_create_historical_record = django.dispatch.Signal(providing_args=[
+    'instance', 'history_instance', 'history_date', 'history_user',
+    'history_change_reason',
+])

--- a/simple_history/tests/tests/test_signals.py
+++ b/simple_history/tests/tests/test_signals.py
@@ -19,11 +19,13 @@ class PrePostCreateHistoricalRecordSignalTest(TestCase):
         self.signal_was_called = False
         self.signal_instance = None
         self.signal_history_instance = None
+        self.signal_sender = None
 
     def test_pre_create_historical_record_signal(self):
         def handler(sender, instance, **kwargs):
             self.signal_was_called = True
             self.signal_instance = instance
+            self.signal_sender = sender
         pre_create_historical_record.connect(handler)
 
         p = Poll(question="what's up?", pub_date=today)
@@ -31,12 +33,14 @@ class PrePostCreateHistoricalRecordSignalTest(TestCase):
 
         self.assertTrue(self.signal_was_called)
         self.assertEqual(self.signal_instance, p)
+        self.assertEqual(self.signal_sender, p.history.first().__class__)
 
     def test_post_create_historical_record_signal(self):
         def handler(sender, instance, history_instance, **kwargs):
             self.signal_was_called = True
             self.signal_instance = instance
             self.signal_history_instance = history_instance
+            self.signal_sender = sender
         post_create_historical_record.connect(handler)
 
         p = Poll(question="what's up?", pub_date=today)
@@ -45,3 +49,4 @@ class PrePostCreateHistoricalRecordSignalTest(TestCase):
         self.assertTrue(self.signal_was_called)
         self.assertEqual(self.signal_instance, p)
         self.assertTrue(self.signal_history_instance is not None)
+        self.assertEqual(self.signal_sender, p.history.first().__class__)

--- a/simple_history/tests/tests/test_signals.py
+++ b/simple_history/tests/tests/test_signals.py
@@ -1,0 +1,47 @@
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+from django.test import TestCase
+
+from simple_history.signals import (
+    pre_create_historical_record,
+    post_create_historical_record,
+)
+
+from ..models import Poll
+
+today = datetime(2021, 1, 1, 10, 0)
+
+
+class PrePostCreateHistoricalRecordSignalTest(TestCase):
+    def setUp(self):
+        self.signal_was_called = False
+        self.signal_instance = None
+        self.signal_history_instance = None
+
+    def test_pre_create_historical_record_signal(self):
+        def handler(sender, instance, **kwargs):
+            self.signal_was_called = True
+            self.signal_instance = instance
+        pre_create_historical_record.connect(handler)
+
+        p = Poll(question="what's up?", pub_date=today)
+        p.save()
+
+        self.assertTrue(self.signal_was_called)
+        self.assertEqual(self.signal_instance, p)
+
+    def test_post_create_historical_record_signal(self):
+        def handler(sender, instance, history_instance, **kwargs):
+            self.signal_was_called = True
+            self.signal_instance = instance
+            self.signal_history_instance = history_instance
+        post_create_historical_record.connect(handler)
+
+        p = Poll(question="what's up?", pub_date=today)
+        p.save()
+
+        self.assertTrue(self.signal_was_called)
+        self.assertEqual(self.signal_instance, p)
+        self.assertTrue(self.signal_history_instance is not None)


### PR DESCRIPTION
As described in the issue below, we are a financial company that needs to guarantee the integrity of our audit logs. We intend to use these signals to implement a custom behavior to send the audit data to an external storage.

This was intended as an internal fork, but it's better for everyone if we implement a generic solution that could be used by anyone.

Some use cases for signals:
- Pushing data to a third party storage (our use case)
- Ignoring some types of changes
- Notifying someone when certain changes occur

## Description
- Added 2 signals (`pre_create_historical_record` and `post_create_historical_record`)
- Changed `create_historical_record` to send the signals accordingly
- Added tests
- Updated the documentation

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/420

## Motivation and Context
Pushing audit data to an external storage to guarantee integrity

## How Has This Been Tested?
I wrote tests that connect to the signals created and test if the connected callback is called and the instance is passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
