### PR TITLE
Added database version to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,6 +25,7 @@ If applicable, add screenshots to help explain your problem.
  - Browser (if applicable): [e.g. chrome, safari]
  - Django Simple History Version: [e.g. 1.9.1]
  - Django Version: [e.g. 1.11.11]
+ - Database Version: [e.g. PostgreSQL 10.5.0]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Added database version so that it's specified in bug reports. Sensing that a few of the bugs we're seeing are from MySQL, but it's helpful if bug reports include that information. Going to do follow on work to test against a variety of dbs.