### PR TITLE
Remove support for MongoDB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ------------------
 - Add pre and post create_historical_record signals (gh-426)
+- Remove support for `django_mongodb_engine` when converting AutoFields
 
 2.3.0 (2018-07-19)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -389,7 +389,7 @@ def transform_field(field):
     """Customize field appropriately for use in historical model"""
     field.name = field.attname
     if isinstance(field, models.AutoField):
-        field.__class__ = convert_auto_field(field)
+        field.__class__ = models.IntegerField
 
     elif isinstance(field, models.FileField):
         # Don't copy file, just path.
@@ -406,20 +406,6 @@ def transform_field(field):
         field._unique = False
         field.db_index = True
         field.serialize = True
-
-
-def convert_auto_field(field):
-    """Convert AutoField to a non-incrementing type
-
-    The historical model gets its own AutoField, so any existing one
-    must be replaced with an IntegerField.
-    """
-    connection = router.db_for_write(field.model)
-    if settings.DATABASES[connection].get('ENGINE') in \
-       ('django_mongodb_engine',):
-        # Check if AutoField is string for django-non-rel support
-        return models.TextField
-    return models.IntegerField
 
 
 class HistoricalObjectDescriptor(object):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -14,7 +14,6 @@ from django.test import TestCase
 
 from simple_history.models import (
     HistoricalRecords,
-    convert_auto_field,
     ModelChange
 )
 from simple_history.utils import update_change_reason
@@ -776,44 +775,6 @@ class HistoryManagerTest(TestCase):
     def test_state_serialization_of_customfk(self):
         from django.db.migrations import state
         state.ModelState.from_model(HistoricalCustomFKError)
-
-
-class TestConvertAutoField(TestCase):
-    """Check what AutoFields get converted to."""
-
-    def setUp(self):
-        for field in Poll._meta.fields:
-            if isinstance(field, models.AutoField):
-                self.field = field
-                break
-
-    def test_relational(self):
-        """Relational test
-
-        Default Django ORM uses an integer-based auto field.
-        """
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning,
-                                    message='Overriding setting DATABASES ' +
-                                            'can lead to unexpected behavior.')
-            with self.settings(DATABASES={'default': {
-                    'ENGINE': 'django.db.backends.postgresql_psycopg2'}}):
-                assert convert_auto_field(self.field) == models.IntegerField
-
-    def test_non_relational(self):
-        """Non-relational test
-
-        MongoDB uses a string-based auto field. We need to make sure
-        the converted field type is string.
-        """
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning,
-                                    message='Overriding setting DATABASES ' +
-                                            'can lead to unexpected behavior.')
-            with self.settings(DATABASES={'default': {
-                    'ENGINE': 'django_mongodb_engine'}}):
-                assert convert_auto_field(self.field) == models.TextField
 
 
 class TestOrderWrtField(TestCase):


### PR DESCRIPTION
Removing support for MongoDB since upstream support for the driver stopped ~3 years ago (the tests are broken and it doesn't support Django >= 1.8). I don't consider this a breaking change since it is already broken.

## Description
Removed support for conditional conversion of `AutoField` and force it to always be converted to an `IntegerField`.

## Motivation and Context
Remove support for a dead project.

## How Has This Been Tested?
Ran `make all`

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
