### PR TITLE
Prepare for 2.4.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changes
 =======
 
-Unreleased
+2.4.0 (2018-09-20)
 ------------------
 - Add pre and post create_historical_record signals (gh-426)
-- Remove support for `django_mongodb_engine` when converting AutoFields
+- Remove support for `django_mongodb_engine` when converting AutoFields (gh-432)
+- Add support for Django 2.1 (gh-418)
 
 2.3.0 (2018-07-19)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.4.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'
 
 
 def register(


### PR DESCRIPTION
Update for release to 2.4.0. 

Changes:
- Add pre and post create_historical_record signals (gh-426)
- Remove support for `django_mongodb_engine` when converting AutoFields (gh-432)
- Add support for Django 2.1 (gh-418)