### PR TITLE
Add feature to allow historical records to be deleted when master is deleted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+----------
+- Add ability to cascade delete historical records when master record is deleted 
+
 2.4.0 (2018-09-20)
 ------------------
 - Add pre and post create_historical_record signals (gh-426)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -424,6 +424,19 @@ If you want to save a model without a historical record, you can use the followi
     poll = Poll(question='something')
     poll.save_without_historical_record()
 
+Deleting historical record
+--------------------------
+
+In some circumstances you may want to delete all the historical records when the master record is deleted.  This can
+be accomplished by setting ``cascade_delete_history=True``.
+
+.. code-block:: python
+
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        history = HistoricalRecords(cascade_delete_history=True)
+
+
 History Diffing
 -------------------
 

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -61,7 +61,7 @@ class WaterLevel(models.Model):
     level = models.IntegerField()
     date = models.DateTimeField()
 
-    history = HistoricalRecords()
+    history = HistoricalRecords(cascade_delete_history=True)
 
     @property
     def _history_date(self):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -170,6 +170,20 @@ class HistoricalRecordsTest(TestCase):
             'history_type': "-"
         })
 
+    def test_cascade_delete_history(self):
+        thames = WaterLevel.objects.create(waters="Thames", level=2.5,
+                                           date=today)
+        nile = WaterLevel.objects.create(waters="Nile", level=2.5,
+                                         date=today)
+
+        self.assertEqual(len(thames.history.all()), 1)
+        self.assertEqual(len(nile.history.all()), 1)
+
+        nile.delete()
+
+        self.assertEqual(len(thames.history.all()), 1)
+        self.assertEqual(len(nile.history.all()), 0)
+
     def test_save_without_historical_record(self):
         pizza_place = Restaurant.objects.create(name='Pizza Place', rating=3)
         pizza_place.rating = 4


### PR DESCRIPTION

## Description
Allow user to specify that they don't want to keep history for deleted models.

## Related Issue
#439 

## Motivation and Context
If users don't want to keep history for deleted data this allows them to do so.

## How Has This Been Tested?
The unit tests have been updated to account for the new functionality.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
