### PR TITLE
Honor a custom admin site_header in the listing and details pages.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,6 +51,7 @@ Authors
 - Ross Rogers
 - Steven Klass
 - Steeve Chailloux
+- Tommy Beadle (@tbeadle)
 - Trey Hunner
 - Ulysses Vilela
 - vnagendra

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,9 @@ Changes
 =======
 
 Unreleased
------------
+----------
 - Add `custom_model_name` parameter to the constructor of `HistoricalRecords` (gh-451)
+- Fix header on history pages when custom site_header is used (gh-448)
 
 2.5.1 (2018-10-19)
 ------------------

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -84,6 +84,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             'admin_user_view': admin_user_view,
             'history_list_display': history_list_display,
         }
+        context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
         return render(request, self.object_history_template, context,
@@ -189,6 +190,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             'save_on_top': self.save_on_top,
             'root_path': getattr(self.admin_site, 'root_path', None),
         }
+        context.update(self.admin_site.each_context(request))
         extra_kwargs = {}
         return render(request, self.object_history_form_template, context,
                       **extra_kwargs)

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -467,6 +467,7 @@ class AdminSiteTest(WebTest):
             'save_on_top': admin.save_on_top,
             'root_path': getattr(admin_site, 'root_path', None),
         }
+        context.update(admin_site.each_context(request))
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context)
 
@@ -522,6 +523,7 @@ class AdminSiteTest(WebTest):
             'save_on_top': admin.save_on_top,
             'root_path': getattr(admin_site, 'root_path', None),
         }
+        context.update(admin_site.each_context(request))
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context)
 
@@ -576,6 +578,7 @@ class AdminSiteTest(WebTest):
             'save_on_top': admin.save_on_top,
             'root_path': getattr(admin_site, 'root_path', None),
         }
+        context.update(admin_site.each_context(request))
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context)
 
@@ -632,5 +635,6 @@ class AdminSiteTest(WebTest):
             'save_on_top': admin.save_on_top,
             'root_path': getattr(admin_site, 'root_path', None),
         }
+        context.update(admin_site.each_context(request))
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context)


### PR DESCRIPTION
## Description
Include the admin site's site_header when generating the context for the pages used in django-simple-history.

## Related Issue
Fixes #205 

## Motivation and Context
Previously, the default "Django Administration" header was being displayed.

## How Has This Been Tested?
Used a sample project and set `admin.site.site_header = 'Something'` in urls.py. Verified that the history listing and details pages show that header. Previously, they showed the default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
