### PR TITLE
Support changeReason for bulk history create

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,6 +40,8 @@ Authors
 - Marty Alchin
 - Mauricio de Abreu Antunes
 - Micah Denbraver
+- Miguel Vargas
+- Nianpeng Li
 - Phillip Marshall
 - Rajesh Pappula
 - Roberto Aguilar

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Unreleased
+-----------
+- Add `'+'` as the `history_type` for each instance in `bulk_history_create` (gh-449)
+- Add support for  `history_change_reason` for each instance in `bulk_history_create` (gh-449)
+
 2.5.0 (2018-10-18)
 ------------------
 - Add ability to cascade delete historical records when master record is deleted (gh-440)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -39,7 +39,7 @@ can add `changeReason` on each instance:
     >>> for poll in data:
             poll.changeReason = 'reason'
     >>> objs = bulk_create_with_history(data, Poll, batch_size=500)
-    >>> Poll.objects.get(id=data[0].id).history_change_reason
+    >>> Poll.history.get(id=data[0].id).history_change_reason
     'reason'
 
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -31,6 +31,18 @@ history:
     >>> Poll.history.count()
     1000
 
+If you want to specify a change reason for each record in the bulk create, you
+can add `changeReason` on each instance:
+
+.. code-block:: pycon
+
+    >>> for poll in data:
+            poll.changeReason = 'reason'
+    >>> objs = bulk_create_with_history(data, Poll, batch_size=500)
+    >>> Poll.objects.get(id=data[0].id).history_change_reason
+    'reason'
+
+
 QuerySet Updates with History
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Unlike with ``bulk_create``, `queryset updates`_ perform an SQL update query on

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -97,6 +97,8 @@ class HistoryManager(models.Manager):
             self.model(
                 history_date=getattr(instance, '_history_date', now()),
                 history_user=getattr(instance, '_history_user', None),
+                history_change_reason=getattr(instance, 'changeReason', ''),
+                history_type='+',
                 **{
                     field.attname: getattr(instance, field.attname)
                     for field in instance._meta.fields

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -104,10 +104,25 @@ class BulkHistoryCreateTestCase(TestCase):
         self.assertQuerysetEqual(Poll.history.order_by('question'), [
             'Question 1', 'Question 2', 'Question 3', 'Question 4'
         ], attrgetter('question'))
+        self.assertTrue(
+            all([history.history_type == '+' for history in Poll.history.all()])
+        )
 
         created = Poll.history.bulk_create([])
         self.assertEqual(created, [])
         self.assertEqual(Poll.history.count(), 4)
+
+    def test_bulk_history_create_with_change_reason(self):
+        for poll in self.data:
+            poll.changeReason = 'reason'
+
+        Poll.history.bulk_history_create(self.data)
+
+        self.assertTrue(
+            all([history.history_change_reason == 'reason'
+                 for history in Poll.history.all()])
+        )
+
 
     def test_bulk_history_create_on_objs_without_ids(self):
         self.data = [

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -105,7 +105,8 @@ class BulkHistoryCreateTestCase(TestCase):
             'Question 1', 'Question 2', 'Question 3', 'Question 4'
         ], attrgetter('question'))
         self.assertTrue(
-            all([history.history_type == '+' for history in Poll.history.all()])
+            all([history.history_type == '+'
+                 for history in Poll.history.all()])
         )
 
         created = Poll.history.bulk_create([])
@@ -122,7 +123,6 @@ class BulkHistoryCreateTestCase(TestCase):
             all([history.history_change_reason == 'reason'
                  for history in Poll.history.all()])
         )
-
 
     def test_bulk_history_create_on_objs_without_ids(self):
         self.data = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Add `'+'` as the `history_type` for each instance in `bulk_history_create`
2. Add support for  `history_change_reason` for each instance in `bulk_history_create`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/treyhunner/django-simple-history/issues/442

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This solves issue #442 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
