### PR TITLE
Issue 341 - Warning if HistoricalRecords(inherit=False) in an abstract class

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -4,6 +4,7 @@ import copy
 import importlib
 import threading
 import uuid
+import warnings
 
 from django.apps import apps
 from django.conf import settings
@@ -71,6 +72,9 @@ class HistoricalRecords(object):
         self.cls = cls
         models.signals.class_prepared.connect(self.finalize, weak=False)
         self.add_extra_methods(cls)
+
+        if cls._meta.abstract and not self.inherit :
+            warnings.warn("Historical records added to abstract model without inherit=true", UserWarning)
 
     def add_extra_methods(self, cls):
         def save_without_historical_record(self, *args, **kwargs):


### PR DESCRIPTION
## Description
Working on this at a sprint at DjangoCon 2018.

I am issuing a Python Error here with warnings.warn. The other option I see is to try to issue it with Django's System Check Framework, but I'm not 100% sure how to do that, since it would probably require extending the check method, but then at that point I'm not sure how I would go about getting the cls object.

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/341

## Motivation and Context
If HistoricalRecords is added to an abstract model and inherit=False, the models that are subclassed from this abstract model will not have their histories saved.

## How Has This Been Tested?
I ran a sample project on Django 2.1 that tried to create an abstract model with HistoricalRecords(inherit=False) and the warning was successfully raised. I also tried to subclass that abstract model and the warning was raised for that subclassed model as well.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I'm not 100% sure how to run further tests, nor am I sure if raising a Python-based exception is the in code style of this project. Please let me know and I'll change things accordingly!