### PR TITLE
Issue #427 added history_change_reason to the history list view as a …

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -68,6 +68,7 @@ Authors
 - Adnan Umer (@uadnan)
 - Jonathan Zvesper (@zvesp)
 - Matheus Cansian (@mscansian)
+- Jim Gomez
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 -----------
 - Add `'+'` as the `history_type` for each instance in `bulk_history_create` (gh-449)
 - Add support for  `history_change_reason` for each instance in `bulk_history_create` (gh-449)
+- Add `history_change_reason` in the history list view under the  `Change reason` display name
 
 2.5.0 (2018-10-18)
 ------------------

--- a/simple_history/templates/simple_history/_object_history_list.html
+++ b/simple_history/templates/simple_history/_object_history_list.html
@@ -13,6 +13,7 @@
       <th scope="col">{% trans 'Date/time' %}</th>
       <th scope="col">{% trans 'Comment' %}</th>
       <th scope="col">{% trans 'Changed by' %}</th>
+      <th scope="col">{% trans 'Change reason' %}</th>
     </tr>
   </thead>
   <tbody>
@@ -35,6 +36,9 @@
           {% else %}
             {% trans "None" %}
           {% endif %}
+        </td>
+        <td>
+            {{ action.history_change_reason }}
         </td>
       </tr>
     {% endfor %}

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -71,12 +71,17 @@ class AdminSiteTest(WebTest):
         self.assertEqual(model_name, 'customuser')
         self.login()
         poll = Poll(question="why?", pub_date=today)
+        poll.changeReason = 'A random test reason'
         poll._history_user = self.user
         poll.save()
+
         response = self.app.get(get_history_url(poll))
         self.assertIn(get_history_url(poll, 0), response.unicode_normal_body)
         self.assertIn("Poll object", response.unicode_normal_body)
         self.assertIn("Created", response.unicode_normal_body)
+        self.assertIn("Changed by", response.unicode_normal_body)
+        self.assertIn("Change reason", response.unicode_normal_body)
+        self.assertIn("A random test reason", response.unicode_normal_body)
         self.assertIn(self.user.username, response.unicode_normal_body)
 
     def test_history_list_custom_fields(self):


### PR DESCRIPTION
…default.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This addresses issue [427](https://github.com/treyhunner/django-simple-history/issues/427) by adding the history_change_reason field to the admin history list view under the table header "Change reason"

## Related Issue
Closes #427 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Added assert statements to test_admin.test_history_list test case

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
