### PR TITLE
Fix custom user error and bump version

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,6 +3,9 @@ Maintainers
 - Trey Hunner
 - Micah Denbraver
 - Ross Mechanic
+- Brian Armstrong
+- Kyle Seever
+- David Grochowksi
 
 Authors
 =======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,12 @@
 Changes
 =======
 
-Unreleased
------------
+2.5.1 (2018-10-22)
+------------------
 - Add `'+'` as the `history_type` for each instance in `bulk_history_create` (gh-449)
 - Add support for  `history_change_reason` for each instance in `bulk_history_create` (gh-449)
-- Add `history_change_reason` in the history list view under the  `Change reason` display name
+- Add `history_change_reason` in the history list view under the  `Change reason` display name (gh-458)
+- Fix bug that caused failures when using a custom user model (gh-459)
 
 2.5.0 (2018-10-18)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.0
+current_version = 2.5.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 
 
 def register(

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -4,12 +4,10 @@ import copy
 import importlib
 import threading
 import uuid
-
 from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.auth import get_user_model
-from django.db import models, router
+from django.db import models
 from django.db.models import Q
 from django.db.models.fields.proxy import OrderWrt
 from django.urls import reverse
@@ -21,12 +19,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from . import exceptions
 from .manager import HistoryDescriptor
-from .signals import (
-    pre_create_historical_record,
-    post_create_historical_record,
-)
+from .signals import (post_create_historical_record, pre_create_historical_record)
 
-User = get_user_model()
 registered_models = {}
 
 
@@ -220,7 +214,9 @@ class HistoricalRecords(object):
     def get_extra_fields(self, model, fields):
         """Return dict of extra fields added to the historical record model"""
 
-        user_model = self.user_model or User
+        user_model = self.user_model or getattr(
+            settings, 'AUTH_USER_MODEL', 'auth.User'
+        )
 
         def revert_url(self):
             """URL for this change in the default admin site."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes bug described in #459 and updates to version 2.5.1 so that we can get this bug fix out today. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #459 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested this locally by creating a custom user model and trying to make migrations in 2.5.0 (which failed). After making these changes, the custom user model migrations worked. Would love to have a better automated test for this, but for now I'd like to just get the fix out for our users. 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
