### PR TITLE
Only fetch the current and previous instances once

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -437,9 +437,11 @@ class HistoricalChanges(object):
 
         changes = []
         changed_fields = []
+        instance = self.instance
+        old_instance = old_history.instance
         for field in self._meta.fields:
-            if hasattr(self.instance, field.name) and \
-               hasattr(old_history.instance, field.name):
+            if hasattr(instance, field.name) and \
+               hasattr(old_instance, field.name):
                 old_value = getattr(old_history, field.name, '')
                 new_value = getattr(self, field.name)
                 if old_value != new_value:


### PR DESCRIPTION
Only fetching the instances once rather than `O(n)` times reduces computation.

## Motivation and Context
This results in fewer operations, and fewer queries being executed, which can have big performance improvements when diffing large objects. This doesn't usually affect the query count, but can when using `excluded_fields`

## How Has This Been Tested?
Primarily by manually munging the code for `django-simple-history` locally. Theoretically there's no user-facing change to this, so the existing unit tests should cover it.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
