### PR TITLE
Prefetch which fields instances have

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -438,7 +438,9 @@ class HistoricalChanges(object):
         changes = []
         changed_fields = []
         instance_fields = [field.name for field in self.instance._meta.fields]
-        old_instance_fields = [field.name for field in old_history.instance._meta.fields]
+        old_instance_fields = [
+            field.name for field in old_history.instance._meta.fields
+        ]
         for field in self._meta.fields:
             if field.name in instance_fields and \
                field.name in old_instance_fields:

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -437,9 +437,11 @@ class HistoricalChanges(object):
 
         changes = []
         changed_fields = []
+        instance_fields = [field.name for field in self.instance._meta.fields]
+        old_instance_fields = [field.name for field in old_history.instance._meta.fields]
         for field in self._meta.fields:
-            if hasattr(self.instance, field.name) and \
-               hasattr(old_history.instance, field.name):
+            if field.name in instance_fields and \
+               field.name in old_instance_fields:
                 old_value = getattr(old_history, field.name, '')
                 new_value = getattr(self, field.name)
                 if old_value != new_value:


### PR DESCRIPTION
Re-implementation of https://github.com/treyhunner/django-simple-history/pull/469

`hasattr` makes database queries for related fields, which can slow down diffing. This is unnecessary when just checking if a field exists for a model.

## Motivation and Context
This results in fewer operations, and fewer queries being executed, which can have big performance improvements when diffing large objects. This doesn't usually affect the query count, but can when using `excluded_fields`

## How Has This Been Tested?
Primarily by manually munging the code for `django-simple-history` locally. Theoretically there's no user-facing change to this, so the existing unit tests should cover it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
