### PR TITLE
GH-341: Warning if HistoricalRecords(inherit=False) in an abstract class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 - Add `custom_model_name` parameter to the constructor of `HistoricalRecords` (gh-451)
 - Fix header on history pages when custom site_header is used (gh-448)
+- Raise warning if HistoricalRecords(inherit=False) is in an abstract model (gh-341)
 
 2.5.1 (2018-10-19)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -73,8 +73,8 @@ class HistoricalRecords(object):
         self.add_extra_methods(cls)
 
         if cls._meta.abstract and not self.inherit:
-            msg = "Historical records added to abstract model without " \
-                  "inherit=true"
+            msg = "HistoricalRecords added to abstract model ({}) without " \
+                  "inherit=True".format(self.cls.__name__)
             warnings.warn(msg, UserWarning)
 
     def add_extra_methods(self, cls):

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -5,7 +5,6 @@ import importlib
 import threading
 import uuid
 import warnings
-
 from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
@@ -22,8 +21,8 @@ from django.utils.translation import ugettext_lazy as _
 from . import exceptions
 from .manager import HistoryDescriptor
 from .signals import (
-    pre_create_historical_record,
     post_create_historical_record,
+    pre_create_historical_record
 )
 
 registered_models = {}
@@ -72,8 +71,10 @@ class HistoricalRecords(object):
         models.signals.class_prepared.connect(self.finalize, weak=False)
         self.add_extra_methods(cls)
 
-        if cls._meta.abstract and not self.inherit :
-            warnings.warn("Historical records added to abstract model without inherit=true", UserWarning)
+        if cls._meta.abstract and not self.inherit:
+            msg = "Historical records added to abstract model without " \
+                  "inherit=true"
+            warnings.warn(msg, UserWarning)
 
     def add_extra_methods(self, cls):
         def save_without_historical_record(self, *args, **kwargs):

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -4,6 +4,7 @@ import copy
 import importlib
 import threading
 import uuid
+import warnings
 
 from django.apps import apps
 from django.conf import settings
@@ -70,6 +71,9 @@ class HistoricalRecords(object):
         self.cls = cls
         models.signals.class_prepared.connect(self.finalize, weak=False)
         self.add_extra_methods(cls)
+
+        if cls._meta.abstract and not self.inherit :
+            warnings.warn("Historical records added to abstract model without inherit=true", UserWarning)
 
     def add_extra_methods(self, cls):
         def save_without_historical_record(self, *args, **kwargs):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1048,3 +1048,22 @@ class ExcludeForeignKeyTest(TestCase):
         historical = self.get_first_historical()
         instance = historical.instance
         self.assertEqual(instance.place, new_place)
+
+
+class WarningOnAbstractModelWithInheritFalseTest(TestCase):
+    def test_warning_on_abstract_model_with_inherit_false(self):
+
+        with warnings.catch_warnings(record=True) as w:
+            class AbstractModelWithInheritFalse(models.Model):
+                string = models.CharField()
+                history = HistoricalRecords()
+
+                class Meta:
+                    abstract = True
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, UserWarning))
+            self.assertEqual(str(w[0].message),
+                             'HistoricalRecords added to abstract model '
+                             '(AbstractModelWithInheritFalse) without '
+                             'inherit=True')


### PR DESCRIPTION
ADAPTED FROM #457 . Thanks @shlywa !
## Description
Working on this at a sprint at DjangoCon 2018.

I am issuing a Python Error here with warnings.warn. The other option I see is to try to issue it with Django's System Check Framework, but I'm not 100% sure how to do that, since it would probably require extending the check method, but then at that point I'm not sure how I would go about getting the cls object.

## Related Issue
Closes #341 

## Motivation and Context
If HistoricalRecords is added to an abstract model and inherit=False, the models that are subclassed from this abstract model will not have their histories saved.

## How Has This Been Tested?
I ran a sample project on Django 2.1 that tried to create an abstract model with HistoricalRecords(inherit=False) and the warning was successfully raised. I also tried to subclass that abstract model and the warning was raised for that subclassed model as well.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. - Tested locally. 
- [x] All new and existing tests passed.

I'm not 100% sure how to run further tests, nor am I sure if raising a Python-based exception is the in code style of this project. Please let me know and I'll change things accordingly!