### PR TITLE
Fix admin template issues on django trunk

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -25,6 +25,7 @@ installed_apps = [
     'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.admin',
+    'django.contrib.messages',
 ]
 
 DEFAULT_SETTINGS = dict(
@@ -45,6 +46,7 @@ DEFAULT_SETTINGS = dict(
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
             ]
         },
     }],

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -194,7 +194,7 @@ class AdminSiteTest(WebTest):
         self.assertEqual(Poll.history.get().history_user, self.user)
 
         # Ensure polls saved on edit page in admin interface save correct user
-        change_page = changelist_page.click("Poll object")
+        change_page = changelist_page.click("Poll object", index=1)
         change_page.form.submit()
         self.assertEqual([p.history_user for p in Poll.history.all()],
                          [self.user, self.user])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Django trunk throws the following errors:
```
ERRORS:
?: (admin.E404) 'django.contrib.messages.context_processors.messages' must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin application.
?: (admin.E406) 'django.contrib.messages' must be in INSTALLED_APPS in order to use the admin application.
```

This adds those to the `runtests.py` file in order to pass tests on trunk. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #473 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Also had to edit one test, since the message on the template returned a duplicate link to the one the test was trying to click. Added a simple index there to fix. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes all current tests
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
