### PR TITLE
Allow user with view permissions to view the history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Authors
 - Daniel Levy
 - Daniel Roschka
 - David Hite
+- Dion Gerritsen
 - Eduardo Cuducos
 - Florian Eßer
 - George Vilches

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Fix header on history pages when custom site_header is used (gh-448)
 - Modify `pre_create_historircal_record` to pass `history_instance` for ease of customization (gh-421)
 - Raise warning if HistoricalRecords(inherit=False) is in an abstract model (gh-341)
+- Let users with view permissions see the model's history (gh-475)
 
 2.5.1 (2018-10-19)
 ------------------

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -58,7 +58,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             except action_list.model.DoesNotExist:
                 raise http.Http404
 
-        if not self.has_change_permission(request, obj):
+        if not self.has_view_permission(request, obj):
             raise PermissionDenied
 
         # Set attribute on each action_list entry from admin methods

--- a/simple_history/templates/simple_history/_object_history_list.html
+++ b/simple_history/templates/simple_history/_object_history_list.html
@@ -19,7 +19,13 @@
   <tbody>
     {% for action in action_list %}
       <tr>
-        <td><a href="{% url opts|admin_urlname:'simple_history' object.pk action.pk %}">{{ action.history_object }}</a></td>
+        <td>
+          {% if has_change_permission %}
+            <a href="{% url opts|admin_urlname:'simple_history' object.pk action.pk %}">{{ action.history_object }}</a>
+          {% else %}
+            {{ action.history_object }}
+          {% endif %}
+        </td>
         {% for column in history_list_display %}
         <td scope="col">{{ action|getattribute:column }}</th>
         {% endfor %}

--- a/simple_history/templates/simple_history/object_history.html
+++ b/simple_history/templates/simple_history/object_history.html
@@ -8,7 +8,9 @@
 {% block content %}
   <div id="content-main">
 
-    <p>{% blocktrans %}Choose a date from the list below to revert to a previous version of this object.{% endblocktrans %}</p>
+    {% if has_change_permission %}
+      <p>{% blocktrans %}Choose a date from the list below to revert to a previous version of this object.{% endblocktrans %}</p>
+    {% endif %}
 
     <div class="module">
       {% if action_list %}


### PR DESCRIPTION
## Description
Currently, a user with view permissions can see the model instance itself, but not the history.
With this change, users with view, but not change permission, can see the history, but not revert etc.

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/475

## Motivation and Context
With this change, users with view, but not change permission, can see the history, but not revert etc.

## How Has This Been Tested?
Has been tested in a project i'm currently developing, and in which I noticed this.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Working on the tests.