### PR TITLE
Add check for _history_excluded_fields

### DIFF
--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -93,6 +93,9 @@ class HistoryManager(models.Manager):
     def bulk_history_create(self, objs, batch_size=None):
         """Bulk create the history for the objects specified by objs"""
 
+        if not hasattr(self.model, '_history_excluded_fields'):
+            self.model._history_excluded_fields = []
+
         historical_instances = [
             self.model(
                 history_date=getattr(instance, '_history_date', now()),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `_history_excluded_fields` in HistoryManager  when the model belongs to Django's `__fake__` module to prevent data migrations from failing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
On a project I'm working on, we're using two migrations to get simple_history up and running: first is the auto-generated one and the second is a data migration, that does what `./manage populate_history --auto` does.

When using data migrations and creating the up and down functions to pass to RunPython, the first argument is the Django registry that contains all installed apps where I can get a temporal version of my HistoricalModel thrgough `get_model`. The problem is that Django gives a fake model, which does not contain `_history_excluded_fields` or any other attributes besides the data ones.

I did a workaround here https://github.com/Linaro/squad/pull/379/commits/3c56e6a01e79c21e96a508599ca99467ffb2f962#diff-637039b1754cb5ac4d81dc43b33d30a1R16

Perhaps adding this check would help others creating data migrations without this workaround


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Just ran simple_history tests, I don't think it'll brake anything, since it'd be adding an attribute in case `self.model` doesn't have it already

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
