### PR TITLE
Duplicate history cleanup

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ Authors
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
 - Eduardo Cuducos
+- Filipe Pina (@fopina)
 - Florian Eßer
 - Frank Sachsenheim
 - George Vilches

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes
 - Add german translations (gh-484)
 - Add `extra_context` parameter to history_form_view (gh-467)
 - Fixed bug that prevented `next_record` and `prev_record` to work with custom manager names (gh-501)
+- Added management command `clean_duplicate_history` to remove duplicate history entries (gh-483)
 
 2.5.1 (2018-10-19)
 ------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -328,3 +328,25 @@ And to revert to that ``HistoricalPoll`` instance, we can do:
 This will change the ``poll`` instance to have the data from the
 ``HistoricalPoll`` object and it will create a new row in the
 ``HistoricalPoll`` table indicating that a new change has been made.
+
+Duplicate history entries
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For performance reasons, ``django-simple-history`` always creates an ``HistoricalRecord``
+when ``Model.save()`` is called regardless of data having actually changed.
+If you find yourself with a lot of history duplicates you can schedule the
+``clean_duplicate_history`` command
+
+.. code-block:: bash
+
+    $ python manage.py clean_duplicate_history --auto
+
+You can use ``--auto`` to clean up duplicates for every model
+with ``HistoricalRecords`` or enumerate specific models as args.
+There is also ``-m/--minutes`` to specify how many minutes to go
+back in history while searching (default checks whole history),
+so you can schedule, for instance, an hourly cronjob such as
+
+.. code-block:: bash
+
+    $ python manage.py clean_duplicate_history -m 60 --auto

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -28,14 +28,10 @@ class Command(populate_history.Command):
             "type",
         )
         parser.add_argument(
-            '-d', '--dry',
-            action='store_true',
-            help='Dry (test) run only, no changes'
+            "-d", "--dry", action="store_true", help="Dry (test) run only, no changes"
         )
         parser.add_argument(
-            '-m', '--minutes',
-            type=int,
-            help='Only search the last MINUTES of history'
+            "-m", "--minutes", type=int, help="Only search the last MINUTES of history"
         )
 
     def handle(self, *args, **options):
@@ -63,7 +59,7 @@ class Command(populate_history.Command):
             if self.verbosity >= 1:
                 self.stdout.write(self.COMMAND_HINT)
 
-        self._process(to_process, date_back=options['minutes'], dry_run=options['dry'])
+        self._process(to_process, date_back=options["minutes"], dry_run=options["dry"])
 
     def _process(self, to_process, date_back=None, dry_run=True):
         if date_back:
@@ -109,9 +105,9 @@ class Command(populate_history.Command):
             if extra_one:
                 entries_deleted += self._check_and_delete(f1, extra_one, dry_run)
         if self.verbosity >= 1:
-            self.stdout.write(self.DONE_CLEANING_FOR_MODEL.format(
-                model=model, count=entries_deleted
-            ))
+            self.stdout.write(
+                self.DONE_CLEANING_FOR_MODEL.format(model=model, count=entries_deleted)
+            )
 
     def _check_and_delete(self, entry1, entry2, dry_run=True):
         delta = entry1.diff_against(entry2)

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -1,0 +1,122 @@
+from django.utils import timezone
+from django.db import transaction
+
+from . import populate_history
+from ... import models, utils
+from ...exceptions import NotHistoricalModelError
+
+get_model = populate_history.get_model
+
+
+class Command(populate_history.Command):
+    args = "<app.model app.model ...>"
+    help = (
+        "Scans HistoricalRecords for identical sequencial entries "
+        "(duplicates) in a model and deletes them."
+    )
+
+    DONE_CLEANING_FOR_MODEL = "Removed {count} historical records for {model}\n"
+
+    def add_arguments(self, parser):
+        parser.add_argument("models", nargs="*", type=str)
+        parser.add_argument(
+            "--auto",
+            action="store_true",
+            dest="auto",
+            default=False,
+            help="Automatically search for models with the HistoricalRecords field "
+            "type",
+        )
+        parser.add_argument(
+            '-d', '--dry',
+            action='store_true',
+            help='Dry (test) run only, no changes'
+        )
+        parser.add_argument(
+            '-m', '--minutes',
+            type=int,
+            help='Only search the last MINUTES of history'
+        )
+
+    def handle(self, *args, **options):
+        self.verbosity = options["verbosity"]
+
+        to_process = set()
+        model_strings = options.get("models", []) or args
+
+        if model_strings:
+            for model_pair in self._handle_model_list(*model_strings):
+                to_process.add(model_pair)
+
+        elif options["auto"]:
+            for model in models.registered_models.values():
+                try:  # avoid issues with mutli-table inheritance
+                    history_model = utils.get_history_model_for_model(model)
+                except NotHistoricalModelError:
+                    continue
+                to_process.add((model, history_model))
+            if not to_process:
+                if self.verbosity >= 1:
+                    self.stdout.write(self.NO_REGISTERED_MODELS)
+
+        else:
+            if self.verbosity >= 1:
+                self.stdout.write(self.COMMAND_HINT)
+
+        self._process(to_process, date_back=options['minutes'], dry_run=options['dry'])
+
+    def _process(self, to_process, date_back=None, dry_run=True):
+        if date_back:
+            stop_date = timezone.now() - timezone.timedelta(minutes=date_back)
+        else:
+            stop_date = None
+
+        for model, history_model in to_process:
+            m_qs = history_model.objects
+            if stop_date:
+                m_qs = m_qs.filter(history_date__gte=stop_date)
+            found = m_qs.count()
+            if self.verbosity >= 2:
+                self.stdout.write("{0} has {1} historical entries".format(model, found))
+            if not found:
+                continue
+
+            # it would be great if we could just iterate over the instances that
+            # have changes (in the given period) but
+            # `m_qs.values(model._meta.pk.name).distinct()`
+            # is actually slower than looping all and filtering in the code...
+            for o in model.objects.all():
+                self._process_instance(o, model, stop_date=stop_date, dry_run=dry_run)
+
+    def _process_instance(self, instance, model, stop_date=None, dry_run=True):
+        entries_deleted = 0
+        o_qs = instance.history.all()
+        if stop_date:
+            # to compare last history match
+            extra_one = o_qs.filter(history_date__lte=stop_date).first()
+            o_qs = o_qs.filter(history_date__gte=stop_date)
+        else:
+            extra_one = None
+        with transaction.atomic():
+            # ordering is ('-history_date', '-history_id') so this is ok
+            f1 = o_qs.first()
+            if not f1:
+                return
+
+            for f2 in o_qs[1:]:
+                entries_deleted += self._check_and_delete(f1, f2, dry_run)
+                f1 = f2
+            if extra_one:
+                entries_deleted += self._check_and_delete(f1, extra_one, dry_run)
+        if self.verbosity >= 1:
+            self.stdout.write(self.DONE_CLEANING_FOR_MODEL.format(
+                model=model, count=entries_deleted
+            ))
+
+    def _check_and_delete(self, entry1, entry2, dry_run=True):
+        delta = entry1.diff_against(entry2)
+        if not delta.changed_fields:
+            if not dry_run:
+                entry1.delete()
+            return 1
+        return 0

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -35,11 +35,6 @@ class Command(populate_history.Command):
     def handle(self, *args, **options):
         self.verbosity = options["verbosity"]
 
-        if options["minutes"]:
-            stop_date = timezone.now() - timezone.timedelta(minutes=options["minutes"])
-        else:
-            stop_date = None
-
         to_process = set()
         model_strings = options.get("models", []) or args
 
@@ -62,9 +57,14 @@ class Command(populate_history.Command):
             if self.verbosity >= 1:
                 self.stdout.write(self.COMMAND_HINT)
 
-        self._process(to_process, stop_date=stop_date, dry_run=options["dry"])
+        self._process(to_process, date_back=options["minutes"], dry_run=options["dry"])
 
-    def _process(self, to_process, stop_date=None, dry_run=True):
+    def _process(self, to_process, date_back=None, dry_run=True):
+        if date_back:
+            stop_date = timezone.now() - timezone.timedelta(minutes=date_back)
+        else:
+            stop_date = None
+
         for model, history_model in to_process:
             m_qs = history_model.objects
             if stop_date:

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -50,12 +50,10 @@ class Command(populate_history.Command):
                     continue
                 to_process.add((model, history_model))
             if not to_process:
-                if self.verbosity >= 1:
-                    self.stdout.write(self.NO_REGISTERED_MODELS)
+                self.log(self.NO_REGISTERED_MODELS)
 
         else:
-            if self.verbosity >= 1:
-                self.stdout.write(self.COMMAND_HINT)
+            self.log(self.COMMAND_HINT)
 
         self._process(to_process, date_back=options["minutes"], dry_run=options["dry"])
 
@@ -70,8 +68,7 @@ class Command(populate_history.Command):
             if stop_date:
                 m_qs = m_qs.filter(history_date__gte=stop_date)
             found = m_qs.count()
-            if self.verbosity >= 2:
-                self.stdout.write("{0} has {1} historical entries".format(model, found))
+            self.log("{0} has {1} historical entries".format(model, found), 2)
             if not found:
                 continue
 
@@ -102,10 +99,14 @@ class Command(populate_history.Command):
                 f1 = f2
             if extra_one:
                 entries_deleted += self._check_and_delete(f1, extra_one, dry_run)
-        if self.verbosity >= 1:
-            self.stdout.write(
-                self.DONE_CLEANING_FOR_MODEL.format(model=model, count=entries_deleted)
-            )
+
+        self.log(
+            self.DONE_CLEANING_FOR_MODEL.format(model=model, count=entries_deleted)
+        )
+
+    def log(self, message, verbosity_level=1):
+        if self.verbosity >= verbosity_level:
+            self.stdout.write(message)
 
     def _check_and_delete(self, entry1, entry2, dry_run=True):
         delta = entry1.diff_against(entry2)

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -43,14 +43,7 @@ class Command(populate_history.Command):
                 to_process.add(model_pair)
 
         elif options["auto"]:
-            for model in models.registered_models.values():
-                try:  # avoid issues with multi-table inheritance
-                    history_model = utils.get_history_model_for_model(model)
-                except NotHistoricalModelError:
-                    continue
-                to_process.add((model, history_model))
-            if not to_process:
-                self.log(self.NO_REGISTERED_MODELS)
+            to_process = self._auto_models()
 
         else:
             self.log(self.COMMAND_HINT)

--- a/simple_history/management/commands/populate_history.py
+++ b/simple_history/management/commands/populate_history.py
@@ -55,21 +55,26 @@ class Command(BaseCommand):
                 to_process.add(model_pair)
 
         elif options["auto"]:
-            for model in models.registered_models.values():
-                try:  # avoid issues with mutli-table inheritance
-                    history_model = utils.get_history_model_for_model(model)
-                except NotHistoricalModelError:
-                    continue
-                to_process.add((model, history_model))
-            if not to_process:
-                if self.verbosity >= 1:
-                    self.stdout.write(self.NO_REGISTERED_MODELS)
+            to_process = self._auto_models()
 
         else:
             if self.verbosity >= 1:
                 self.stdout.write(self.COMMAND_HINT)
 
         self._process(to_process, batch_size=options["batchsize"])
+
+    def _auto_models(self):
+        to_process = set()
+        for model in models.registered_models.values():
+            try:  # avoid issues with multi-table inheritance
+                history_model = utils.get_history_model_for_model(model)
+            except NotHistoricalModelError:
+                continue
+            to_process.add((model, history_model))
+        if not to_process:
+            if self.verbosity >= 1:
+                self.stdout.write(self.NO_REGISTERED_MODELS)
+        return to_process
 
     def _handle_model_list(self, *args):
         failing = False

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -211,8 +211,7 @@ class TestCleanDuplicateHistory(TestCase):
 
     def test_auto_cleanup(self):
         p = Poll.objects.create(
-            question="Will this be deleted?",
-            pub_date=datetime.now()
+            question="Will this be deleted?", pub_date=datetime.now()
         )
         self.assertEqual(Poll.history.all().count(), 1)
         p.save()
@@ -222,20 +221,18 @@ class TestCleanDuplicateHistory(TestCase):
         self.assertEqual(Poll.history.all().count(), 3)
         out = StringIO()
         management.call_command(
-            self.command_name, auto=True,
-            stdout=out, stderr=StringIO()
+            self.command_name, auto=True, stdout=out, stderr=StringIO()
         )
         self.assertEqual(
             out.getvalue(),
             "Removed 1 historical records for "
-            "<class 'simple_history.tests.models.Poll'>\n"
+            "<class 'simple_history.tests.models.Poll'>\n",
         )
         self.assertEqual(Poll.history.all().count(), 2)
 
     def test_auto_cleanup_verbose(self):
         p = Poll.objects.create(
-            question="Will this be deleted?",
-            pub_date=datetime.now()
+            question="Will this be deleted?", pub_date=datetime.now()
         )
         self.assertEqual(Poll.history.all().count(), 1)
         p.save()
@@ -244,15 +241,18 @@ class TestCleanDuplicateHistory(TestCase):
         self.assertEqual(Poll.history.all().count(), 3)
         out = StringIO()
         management.call_command(
-            self.command_name, "tests.poll",
-            auto=True, verbosity=2,
-            stdout=out, stderr=StringIO()
+            self.command_name,
+            "tests.poll",
+            auto=True,
+            verbosity=2,
+            stdout=out,
+            stderr=StringIO(),
         )
         self.assertEqual(
             out.getvalue(),
             "<class 'simple_history.tests.models.Poll'> has 3 historical entries\n"
             "Removed 1 historical records for "
-            "<class 'simple_history.tests.models.Poll'>\n"
+            "<class 'simple_history.tests.models.Poll'>\n",
         )
         self.assertEqual(Poll.history.all().count(), 2)
 
@@ -276,8 +276,11 @@ class TestCleanDuplicateHistory(TestCase):
             h.save()
 
         management.call_command(
-            self.command_name, auto=True, minutes=50,
-            stdout=StringIO(), stderr=StringIO()
+            self.command_name,
+            auto=True,
+            minutes=50,
+            stdout=StringIO(),
+            stderr=StringIO(),
         )
         self.assertEqual(Poll.history.all().count(), 4)
 
@@ -303,8 +306,11 @@ class TestCleanDuplicateHistory(TestCase):
             h.save()
 
         management.call_command(
-            self.command_name, auto=True, minutes=50,
-            stdout=StringIO(), stderr=StringIO()
+            self.command_name,
+            auto=True,
+            minutes=50,
+            stdout=StringIO(),
+            stderr=StringIO(),
         )
         # even though only the last 2 entries match the date range
         # the "extra_one" (the record before the oldest match)


### PR DESCRIPTION
Management command to find (and remove) duplicate entries in history

## Description

Management command to find (and remove) duplicate entries in history `clean_duplicate_history`

## Related Issue
fixes #313 

## Motivation and Context
As discussed in #313 there are cases where we just `.save()` without checking if anything actually changed (as we didn't have the original data loaded).  
For the same reason, doing that check in `simple_history` would have a big performance impact (force a SELECT before any UPDATE) for something that is not required by everyone (as I also prefer performance over clean history).

But we can have both (performance and clean history) if we clean up the history "later" hence I made a management command like this one over an year ago and been using it in quite a few apps so far.

Now I finally decided to rewrite it according to the code style of this project and share it :)

## How Has This Been Tested?
Unit test made (and included) and manual testing using a test app (basically doing the same scripted in the unit test)
* Create instance
* Use admin to edit and save a few times (without changing data)
* Do it once again changing data
* Run command and verify that only 2 entries of history exist (creation and latest one where data actually changed)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.