### PR TITLE
Set app label via instantiation of historical records

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -73,6 +73,7 @@ Authors
 - Jim Gomez
 - Hanyin Zhang
 - James Muranga (@jamesmura)
+- Christopher Broderick (@uhurusurfa)
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 Unreleased
 ----------
+- Add `app` parameter to the constructor of `HistoricalRecords` (gh-486)
 - Add `custom_model_name` parameter to the constructor of `HistoricalRecords` (gh-451)
 - Fix header on history pages when custom site_header is used (gh-448)
 - Modify `pre_create_historircal_record` to pass `history_instance` for ease of customization (gh-421)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -541,3 +541,24 @@ To connect the signals to your callbacks, you can use the @receiver decorator:
     @receiver(post_create_historical_record)
     def post_create_historical_record_callback(sender, **kwargs):
         print("Sent after saving historical record")
+
+History Model In Different App
+------------------------------
+
+By default the app_label for the history model is the same as the base model.
+In some circumstances you may want to have the history models belong in a different app.
+This will support creating history models in a different database to the base model using
+database routing functionality based on app_label.
+To configure history models in a different app, add this to the HistoricalRecords instantiation
+or the record invocation: ``app="SomeAppName"``.
+
+.. code-block:: python
+
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        history = HistoricalRecords(app="SomeAppName")
+
+    class Opinion(models.Model):
+        opinion = models.CharField(max_length=2000)
+
+    register(Opinion, app="SomeAppName")

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -50,6 +50,7 @@ class HistoricalRecords(object):
         get_user=default_get_user,
         cascade_delete_history=False,
         custom_model_name=None,
+        app=None,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -61,6 +62,7 @@ class HistoricalRecords(object):
         self.get_user = get_user
         self.cascade_delete_history = cascade_delete_history
         self.custom_model_name = custom_model_name
+        self.app = app
         if excluded_fields is None:
             excluded_fields = []
         self.excluded_fields = excluded_fields
@@ -340,6 +342,8 @@ class HistoricalRecords(object):
         else:
             name = format_lazy("historical {}", smart_text(model._meta.verbose_name))
         meta_fields["verbose_name"] = name
+        if self.app:
+            meta_fields["app_label"] = self.app
         return meta_fields
 
     def post_save(self, instance, created, **kwargs):

--- a/simple_history/registry_tests/tests.py
+++ b/simple_history/registry_tests/tests.py
@@ -28,6 +28,7 @@ from ..tests.models import (
     UUIDRegisterModel,
     Voter,
     ModelWithCustomAttrForeignKey,
+    ModelWithHistoryInDifferentApp,
 )
 
 get_model = apps.get_model
@@ -211,3 +212,11 @@ class TestMigrate(TestCase):
         management.call_command(
             "migrate", "migration_test_app", fake=True, stdout=StringIO()
         )
+
+
+class TestModelWithHistoryInDifferentApp(TestCase):
+    """ https://github.com/treyhunner/django-simple-history/issues/485 """
+
+    def test__different_app(self):
+        appLabel = ModelWithHistoryInDifferentApp.history.model._meta.app_label
+        self.assertEqual(appLabel, "external")

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -356,6 +356,11 @@ class ContactRegister(models.Model):
 register(ContactRegister, table_name="contacts_register_history")
 
 
+class ModelWithHistoryInDifferentApp(models.Model):
+    name = models.CharField(max_length=30)
+    history = HistoricalRecords(app="external")
+
+
 ###############################################################################
 #
 # Inheritance examples


### PR DESCRIPTION
## Description
Provide the ability to override the app_label Meta attribute on the generated history model.
This functionality alreay exists using the register method. The mechanism for this feature is identical
to the way it is implemented in the register method by allowing passing an app name in the instantiation.
The code change adds an additional instantiation parameter to the __init__ method for the HistoricalRecords class
and then uses this parameter if provided in the get_meta_data method.

## Related Issue
Fixes #485 

## Motivation and Context
It is often desirable to have the app_label different to the base model so that the history models can be directed to a different database.
This enhances security of the audit trail and can be used in situations where there is a need ot reduce the load on the  main application database.
This also provides the same functionality between the "register()" and "HistoricalRecords()" mechanism for initiating audit trails on base models.

## How Has This Been Tested?
A unit test was included to test this change. It only affects the setting of a Meta class attribute and does not functionally change the app code.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
NOTE: There is 1 test that failed but failed even without the code change