### PR TITLE
Select related users when displaying history in admin

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -48,7 +48,9 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         pk_name = opts.pk.attname
         history = getattr(model, model._meta.simple_history_manager_attribute)
         object_id = unquote(object_id)
-        action_list = history.filter(**{pk_name: object_id}).select_related('history_user')
+        action_list = history.filter(**{pk_name: object_id}).select_related(
+            "history_user"
+        )
         history_list_display = getattr(self, "history_list_display", [])
         # If no history was found, see whether this object even exists.
         try:

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -48,7 +48,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         pk_name = opts.pk.attname
         history = getattr(model, model._meta.simple_history_manager_attribute)
         object_id = unquote(object_id)
-        action_list = history.filter(**{pk_name: object_id})
+        action_list = history.filter(**{pk_name: object_id}).select_related('history_user')
         history_list_display = getattr(self, "history_list_display", [])
         # If no history was found, see whether this object even exists.
         try:


### PR DESCRIPTION
This is to avoid n+1 queries

fixes #495 

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/495

## Motivation and Context
It solves n+1 queries

## How Has This Been Tested?
## Screenshots (if appropriate):
**Before**
<img width="1665" alt="screenshot 2018-12-07 at 11 03 38" src="https://user-images.githubusercontent.com/7032667/49641230-d7656500-fa0f-11e8-9041-6f6569899c8b.png">

**After**
<img width="1648" alt="screenshot 2018-12-07 at 11 05 09" src="https://user-images.githubusercontent.com/7032667/49641285-fcf26e80-fa0f-11e8-86a6-bc5e6634b25a.png">




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
