### PR TITLE
create historical instance with respect to using() for multidb enviro…

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,7 +28,7 @@ Authors
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
 - Eduardo Cuducos
-- Erik van Widenfelt (@erikvw)
+- Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
 - Filipe Pina (@fopina)
 - Florian Eßer
 - Frank Sachsenheim

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,6 +28,7 @@ Authors
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
 - Eduardo Cuducos
+- Erik van Widenfelt (@erikvw)
 - Filipe Pina (@fopina)
 - Florian Eßer
 - Frank Sachsenheim

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+----------
+- Add support for `using` chained manager method and save/delete keyword argument (gh-507)
+
 2.6.0 (2018-12-12)
 ------------------
 - Add `app` parameter to the constructor of `HistoricalRecords` (gh-486)

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -510,10 +510,10 @@ When interacting with manager methods, use ``db_manager()``:
 
 .. code-block:: python
 
-    >>> # This will call the manager method on the 'other' database.
+    >>> # This will call a manager method on the 'other' database.
     >>> poll.history.db_manager('other').as_of(datetime(2010, 10, 25, 18, 4, 0))
 
-See the Django documentation for more information on interacting with Multiple databases.
+See the Django documentation for more information on how to interact with multiple databases.
 
 
 History Diffing

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -488,7 +488,7 @@ be accomplished by setting ``cascade_delete_history=True``.
 
 Multiple databases
 ------------------
-`django-simple-history` follows the Django convention for interacting with multiple databases.
+`django-simple-history` follows the Django conventions for interacting with multiple databases.
 
 .. code-block:: python
 
@@ -512,9 +512,6 @@ When interacting with manager methods, use ``db_manager()``:
 
     >>> # This will call the manager method on the 'other' database.
     >>> poll.history.db_manager('other').as_of(datetime(2010, 10, 25, 18, 4, 0))
-    <Poll: Poll object as of 2010-10-25 18:03:29.855689>
-    >>> poll.history.db_manager('other').as_of(datetime(2010, 10, 25, 18, 5, 0))
-    <Poll: Poll object as of 2010-10-25 18:04:13.814128>
 
 See the Django documentation for more information on interacting with Multiple databases.
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -486,6 +486,39 @@ be accomplished by setting ``cascade_delete_history=True``.
         history = HistoricalRecords(cascade_delete_history=True)
 
 
+Multiple databases
+------------------
+`django-simple-history` follows the Django convention for interacting with multiple databases.
+
+.. code-block:: python
+
+    >>> # This will create a new historical record on the 'other' database.
+    >>> poll = Poll.objects.using('other').create(question='Question 1')
+
+    >>> # This will also create a new historical record on the 'other' database.
+    >>> poll.save(using='other')
+
+
+When interacting with ``QuerySets``, use ``using()``:
+
+.. code-block:: python
+
+    >>> # This will return a QuerySet from the 'other' database.
+    Poll.history.using('other').all()
+
+When interacting with manager methods, use ``db_manager()``:
+
+.. code-block:: python
+
+    >>> # This will call the manager method on the 'other' database.
+    >>> poll.history.db_manager('other').as_of(datetime(2010, 10, 25, 18, 4, 0))
+    <Poll: Poll object as of 2010-10-25 18:03:29.855689>
+    >>> poll.history.db_manager('other').as_of(datetime(2010, 10, 25, 18, 5, 0))
+    <Poll: Poll object as of 2010-10-25 18:04:13.814128>
+
+See the Django documentation for more information on interacting with Multiple databases.
+
+
 History Diffing
 -------------------
 
@@ -523,6 +556,8 @@ history_change_reason
     Freetext description of the reason for the change
 history_user
     The user that instigated the change
+using
+    The database alias being used
 
 To connect the signals to your callbacks, you can use the @receiver decorator:
 

--- a/runtests.py
+++ b/runtests.py
@@ -39,7 +39,7 @@ DEFAULT_SETTINGS = dict(
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
         },
-        'other_db': {
+        'other': {
             'ENGINE': 'django.db.backends.sqlite3',
         }
     },

--- a/runtests.py
+++ b/runtests.py
@@ -38,6 +38,9 @@ DEFAULT_SETTINGS = dict(
     DATABASES={
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
+        },
+        'other_db': {
+            'ENGINE': 'django.db.backends.sqlite3',
         }
     },
     TEMPLATES=[{

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -352,12 +352,11 @@ class HistoricalRecords(object):
     def post_save(self, instance, created, **kwargs):
         if not created and hasattr(instance, "skip_history_when_saving"):
             return
-        if not kwargs.get('raw', False):
-            self.create_historical_record(
-                instance, created and '+' or '~', **kwargs)
+        if not kwargs.get("raw", False):
+            self.create_historical_record(instance, created and "+" or "~", **kwargs)
 
     def post_delete(self, instance, **kwargs):
-        self.create_historical_record(instance, '-', **kwargs)
+        self.create_historical_record(instance, "-", **kwargs)
 
     def create_historical_record(self, instance, history_type, using=None, **kwargs):
         history_date = getattr(instance, "_history_date", now())

--- a/simple_history/signals.py
+++ b/simple_history/signals.py
@@ -8,6 +8,7 @@ pre_create_historical_record = django.dispatch.Signal(
         "history_date",
         "history_user",
         "history_change_reason",
+        "using",
     ]
 )
 post_create_historical_record = django.dispatch.Signal(
@@ -17,5 +18,6 @@ post_create_historical_record = django.dispatch.Signal(
         "history_date",
         "history_user",
         "history_change_reason",
+        "using",
     ]
 )

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1230,7 +1230,7 @@ class MultiDBWithUsingTest(TestCase):
     """
 
     multi_db = True
-    db_name = "other_db"
+    db_name = "other"
 
     def test_multidb_with_using_not_on_default(self):
         book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1230,49 +1230,47 @@ class MultiDBWithUsingTest(TestCase):
     """
 
     multi_db = True
-    db_name = 'other_db'
+    db_name = "other_db"
 
     def test_multidb_with_using_not_on_default(self):
-        book = Book.objects.using(self.db_name).create(isbn='1-84356-028-1')
-        self.assertRaises(ObjectDoesNotExist,
-                          book.history.get, isbn='1-84356-028-1')
+        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
+        self.assertRaises(ObjectDoesNotExist, book.history.get, isbn="1-84356-028-1")
 
     def test_multidb_with_using_is_on_dbtwo(self):
-        book = Book.objects.using(self.db_name).create(isbn='1-84356-028-1')
+        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
         try:
-            book.history.using(self.db_name).get(isbn='1-84356-028-1')
+            book.history.using(self.db_name).get(isbn="1-84356-028-1")
         except ObjectDoesNotExist:
-            self.fail('ObjectDoesNotExist unexpectedly raised.')
+            self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_and_fk_not_on_default(self):
-        book = Book.objects.using(self.db_name).create(isbn='1-84356-028-1')
+        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
         library = Library.objects.using(self.db_name).create(book=book)
         self.assertRaises(ObjectDoesNotExist, library.history.get, book=book)
 
     def test_multidb_with_using_and_fk_on_dbtwo(self):
-        book = Book.objects.using(self.db_name).create(isbn='1-84356-028-1')
+        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
         library = Library.objects.using(self.db_name).create(book=book)
         try:
             library.history.using(self.db_name).get(book=book)
         except ObjectDoesNotExist:
-            self.fail('ObjectDoesNotExist unexpectedly raised.')
+            self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_not_on_default(self):
-        book = Book(isbn='1-84356-028-1')
+        book = Book(isbn="1-84356-028-1")
         book.save(using=self.db_name)
-        self.assertRaises(ObjectDoesNotExist,
-                          book.history.get, isbn='1-84356-028-1')
+        self.assertRaises(ObjectDoesNotExist, book.history.get, isbn="1-84356-028-1")
 
     def test_multidb_with_using_keyword_in_save_on_dbtwo(self):
-        book = Book(isbn='1-84356-028-1')
+        book = Book(isbn="1-84356-028-1")
         book.save(using=self.db_name)
         try:
-            book.history.using(self.db_name).get(isbn='1-84356-028-1')
+            book.history.using(self.db_name).get(isbn="1-84356-028-1")
         except ObjectDoesNotExist:
-            self.fail('ObjectDoesNotExist unexpectedly raised.')
+            self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_with_fk(self):
-        book = Book(isbn='1-84356-028-1')
+        book = Book(isbn="1-84356-028-1")
         book.save(using=self.db_name)
         library = Library(book=book)
         library.save(using=self.db_name)
@@ -1282,32 +1280,32 @@ class MultiDBWithUsingTest(TestCase):
         try:
             library.history.using(self.db_name).get(book=book)
         except ObjectDoesNotExist:
-            self.fail('ObjectDoesNotExist unexpectedly raised.')
+            self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_and_update(self):
-        book = Book.objects.using(self.db_name).create(isbn='1-84356-028-1')
+        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
         book.save(using=self.db_name)
         self.assertEqual(
-            ['+', '~'],
+            ["+", "~"],
             [
                 obj.history_type
                 for obj in book.history.using(self.db_name)
                 .all()
-                .order_by('history_date')
+                .order_by("history_date")
             ],
         )
 
     def test_multidb_with_using_keyword_in_save_and_delete(self):
         HistoricalBook = get_history_model_for_model(Book)
-        book = Book.objects.using(self.db_name).create(isbn='1-84356-028-1')
+        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
         book.save(using=self.db_name)
         book.delete(using=self.db_name)
         self.assertEqual(
-            ['+', '~', '-'],
+            ["+", "~", "-"],
             [
                 obj.history_type
                 for obj in HistoricalBook.objects.using(self.db_name)
                 .all()
-                .order_by('history_date')
+                .order_by("history_date")
             ],
         )


### PR DESCRIPTION
Modify so historical record works in a multi-database setup by respecting Django's queryset chained method `using()` and the `using` keyword argument of `save()` and `delete()`.

## Description
In a multi-database environment, historical instances should be created in the same DB as the parent model instance. Currently this is not the case.

For example, if `settings` defines multiple databases:

    DATABASES={
        'default': {
            'ENGINE': 'django.db.backends.sqlite3',
        },
        'other': {
            'ENGINE': 'django.db.backends.sqlite3',
        }
    },

... the following code will create historical records in database `default` regardless of the value passed to `using()`:
    
    # book1 instance is created in `default`;
    # book1 historical instance is created in `default`.
    book1 = Book.objects.create(isbn='1-84356-028-1')

    # book2 instance is created in `other`;
    # book2 historical instance is created in `default` -- which is incorrect.
    book2 = Book.objects.using('other').create(isbn='1-84356-028-2')

... the same incorrect behavior is seen with `save()` and `delete()`:

    # book2 instance is created in `other`;
    # book2 historical instance is created in `default` -- which is incorrect.
    book2 = Book(isbn='1-84356-028-2')
    book2.save(using='other')

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We use this module in a multi-database environment and detected this problem.

## How Has This Been Tested?
Tests have been added to `test_models.py`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.