### PR TITLE
GH-512: allow foreign key to reference self using self str

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 - Add support for `using` chained manager method and save/delete keyword argument (gh-507)
 - Added management command `clean_duplicate_history` to remove duplicate history entries (gh-483)
 - Updated most_recent to work with excluded_fields (gh-477)
+- Fixed bug that prevented self-referential foreign key from using `'self'` (gh-513)
 
 2.6.0 (2018-12-12)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -217,8 +217,8 @@ class HistoricalRecords(object):
                 # has a foreign key to itself. If we pass the historical record's
                 # field to = 'self', the foreign key will point to an historical
                 # record rather than the base record. We can use old_field.model here.
-                if field_args.get('to', None) == 'self':
-                    field_args['to'] = old_field.model
+                if field_args.get("to", None) == "self":
+                    field_args["to"] = old_field.model
 
                 # Override certain arguments passed when creating the field
                 # so that they work for the historical field.

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -213,6 +213,13 @@ class HistoricalRecords(object):
                 else:
                     FieldType = type(old_field)
 
+                # If field_args['to'] is 'self' then we have a case where the object
+                # has a foreign key to itself. If we pass the historical record's
+                # field to = 'self', the foreign key will point to an historical
+                # record rather than the base record. We can use old_field.model here.
+                if field_args.get('to', None) == 'self':
+                    field_args['to'] = old_field.model
+
                 # Override certain arguments passed when creating the field
                 # so that they work for the historical field.
                 field_args.update(

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -553,3 +553,9 @@ class CustomNameModel(models.Model):
 class CustomManagerNameModel(models.Model):
     name = models.CharField(max_length=15)
     log = HistoricalRecords()
+
+
+class ForeignKeyToSelfModel(models.Model):
+    fk_to_self = models.ForeignKey("ForeignKeyToSelfModel", null=True, related_name="+")
+    fk_to_self_using_str = models.ForeignKey("self", null=True, related_name="+")
+    history = HistoricalRecords()

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -556,6 +556,10 @@ class CustomManagerNameModel(models.Model):
 
 
 class ForeignKeyToSelfModel(models.Model):
-    fk_to_self = models.ForeignKey("ForeignKeyToSelfModel", null=True, related_name="+")
-    fk_to_self_using_str = models.ForeignKey("self", null=True, related_name="+")
+    fk_to_self = models.ForeignKey(
+        "ForeignKeyToSelfModel", null=True, related_name="+", on_delete=models.CASCADE
+    )
+    fk_to_self_using_str = models.ForeignKey(
+        "self", null=True, related_name="+", on_delete=models.CASCADE
+    )
     history = HistoricalRecords()

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1322,6 +1322,5 @@ class ForeignKeyToSelfTest(TestCase):
 
     def test_foreign_key_to_self_using_self_str(self):
         self.assertEqual(
-            ForeignKeyToSelfModel,
-            self.history_model.fk_to_self_using_str.field.remote_field.model,
+            self.model, self.history_model.fk_to_self_using_str.field.remote_field.model
         )

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import unittest
+
 import uuid
 import warnings
 from datetime import datetime, timedelta
@@ -43,6 +44,7 @@ from ..models import (
     ExternalModel1,
     ExternalModel3,
     FileModel,
+    ForeignKeyToSelfModel,
     HistoricalChoice,
     HistoricalCustomFKError,
     HistoricalPoll,
@@ -583,7 +585,6 @@ class GetPrevRecordAndNextRecordTestCase(TestCase):
         self.poll.save()
 
     def test_get_prev_record(self):
-
         self.poll.question = "ask questions?"
         self.poll.save()
         self.poll.question = "eh?"
@@ -1203,7 +1204,6 @@ class ExtraFieldsDynamicIPAddressTestCase(TestCase):
 
 class WarningOnAbstractModelWithInheritFalseTest(TestCase):
     def test_warning_on_abstract_model_with_inherit_false(self):
-
         with warnings.catch_warnings(record=True) as w:
 
             class AbstractModelWithInheritFalse(models.Model):
@@ -1224,7 +1224,6 @@ class WarningOnAbstractModelWithInheritFalseTest(TestCase):
 
 
 class MultiDBWithUsingTest(TestCase):
-
     """Asserts historical manager respects `using()` and the `using`
     keyword argument in `save()`.
     """
@@ -1308,4 +1307,21 @@ class MultiDBWithUsingTest(TestCase):
                 .all()
                 .order_by("history_date")
             ],
+        )
+
+
+class ForeignKeyToSelfTest(TestCase):
+    def setUp(self):
+        self.model = ForeignKeyToSelfModel
+        self.history_model = self.model.history.model
+
+    def test_foreign_key_to_self_using_model_str(self):
+        self.assertEqual(
+            self.model, self.history_model.fk_to_self.field.remote_field.model
+        )
+
+    def test_foreign_key_to_self_using_self_str(self):
+        self.assertEqual(
+            ForeignKeyToSelfModel,
+            self.history_model.fk_to_self_using_str.field.remote_field.model,
         )


### PR DESCRIPTION
…nKey to self

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds tests for models with foreign keys to themselves. It also adds functionality (which was accidentally removed in #462) that allows developers to use a `'self'` string when creating a self-referential foreign key. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #512 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users that use the string `'self'` when using self-referential ForeignKeys will likely see migrations when updating from django-simple-history 2.5.1 to 2.6.0. Those migrations will point the historical foreign keys to the historical models rather than the base models. This can be fixed locally by using the model's name rather than `'self'`, as shown below:
```
class SelfReferentialModel(models.Model):
    fk_to_self = models.ForeignKey('SelfReferentialModel')  # this still works in 2.6.0
    fk_to_self = models.ForeignKey('self') # this is broken is 2.6.0 but will be fixed with this PR 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added 2 tests:
1. Checks that a self-referential foreign key using a string of the model's name results in the correct foreign key on the historical model (this worked before the change)
2. Checks that a self-referential foreign key using a string of `'self'` results in the correct foreign key on the historical model (this is fixed by this PR) 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
