### PR TITLE
Remove get_excluded_fields function from manager – shouldn't be part …

### DIFF
--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -34,9 +34,6 @@ class HistoryManager(models.Manager):
             key_name = self.instance._meta.pk.name
         return self.get_super_queryset().filter(**{key_name: self.instance.pk})
 
-    def get_excluded_fields(self):
-        return getattr(self.model, "_history_excluded_fields", [])
-
     def most_recent(self):
         """
         Returns the most recent copy of the instance available in the history.
@@ -48,7 +45,7 @@ class HistoryManager(models.Manager):
                 )
             )
         tmp = []
-        excluded_fields = self.get_excluded_fields()
+        excluded_fields = getattr(self.model, "_history_excluded_fields", [])
 
         for field in self.instance._meta.fields:
             if field.name in excluded_fields:


### PR DESCRIPTION
…of public API

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In #477, `get_excluded_fields` was added to the history manager since the initial version of that PR had a more complicated function definition for `get_excluded_fields`. Since that function is only now used in one place and only consists of one line, I'd rather not have it part of the public API for history manager, so I'm removing it before the next release. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All current tests pass
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
