### PR TITLE
Use model view permissions to prevent a user from "reverting" to a previous version

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -15,55 +15,50 @@ from django.utils.html import mark_safe
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
-USER_NATURAL_KEY = tuple(key.lower()
-                         for key in settings.AUTH_USER_MODEL.split(".", 1))
+USER_NATURAL_KEY = tuple(key.lower() for key in settings.AUTH_USER_MODEL.split(".", 1))
 
 SIMPLE_HISTORY_EDIT = getattr(settings, "SIMPLE_HISTORY_EDIT", False)
 
 
 class HistoricalModelPermissionsAdminMixin:
-
     def get_historical_permission_codename(self, action, opts):
         """
         Return the codename of the permission for the specified action.
         """
-        return '%s_historical%s' % (action, opts.model_name)
+        return "%s_historical%s" % (action, opts.model_name)
 
     def has_add_permission(self, request):
         opts = self.opts
-        historical_codename = self.get_historical_permission_codename(
-            'add', opts)
-        return (super().has_add_permission(request)
-                and request.user.has_perm(
-                    "%s.%s" % (opts.app_label, historical_codename)))
+        historical_codename = self.get_historical_permission_codename("add", opts)
+        return super().has_add_permission(request) and request.user.has_perm(
+            "%s.%s" % (opts.app_label, historical_codename)
+        )
 
     def has_change_permission(self, request, obj=None):
         opts = self.opts
-        historical_codename = self.get_historical_permission_codename(
-            'change', opts)
-        return (super().has_change_permission(request, obj)
-                and request.user.has_perm(
-                    "%s.%s" % (opts.app_label, historical_codename)))
+        historical_codename = self.get_historical_permission_codename("change", opts)
+        return super().has_change_permission(request, obj) and request.user.has_perm(
+            "%s.%s" % (opts.app_label, historical_codename)
+        )
 
     def has_delete_permission(self, request, obj=None):
         opts = self.opts
-        historical_codename = self.get_historical_permission_codename(
-            'delete', opts)
-        return (super().has_delete_permission(request, obj)
-                and request.user.has_perm(
-                    "%s.%s" % (opts.app_label, historical_codename)))
+        historical_codename = self.get_historical_permission_codename("delete", opts)
+        return super().has_delete_permission(request, obj) and request.user.has_perm(
+            "%s.%s" % (opts.app_label, historical_codename)
+        )
 
     def has_view_permission(self, request, obj=None):
         opts = self.opts
-        historical_codename_view = self.get_historical_permission_codename(
-            'view', opts)
+        historical_codename_view = self.get_historical_permission_codename("view", opts)
         historical_codename_change = self.get_historical_permission_codename(
-            'change', opts)
-        historical_perms = (
-            request.user.has_perm(
-                '%s.%s' % (opts.app_label, historical_codename_view))
-            or request.user.has_perm(
-                '%s.%s' % (opts.app_label, historical_codename_change)))
+            "change", opts
+        )
+        historical_perms = request.user.has_perm(
+            "%s.%s" % (opts.app_label, historical_codename_view)
+        ) or request.user.has_perm(
+            "%s.%s" % (opts.app_label, historical_codename_change)
+        )
         try:
             has_view_permission = super().has_view_permission(request, obj)
         except AttributeError:  # < Django 2.1
@@ -72,8 +67,9 @@ class HistoricalModelPermissionsAdminMixin:
         return has_view_permission and historical_perms
 
     def has_view_or_change_permission(self, request, obj=None):
-        return (self.has_view_permission(request, obj)
-                or self.has_change_permission(request, obj))
+        return self.has_view_permission(request, obj) or self.has_change_permission(
+            request, obj
+        )
 
 
 class SimpleHistoryAdmin(HistoricalModelPermissionsAdminMixin, admin.ModelAdmin):
@@ -127,17 +123,16 @@ class SimpleHistoryAdmin(HistoricalModelPermissionsAdminMixin, admin.ModelAdmin)
             value_for_entry = getattr(self, history_list_entry, None)
             if value_for_entry and callable(value_for_entry):
                 for list_entry in action_list:
-                    setattr(list_entry, history_list_entry,
-                            value_for_entry(list_entry))
+                    setattr(list_entry, history_list_entry, value_for_entry(list_entry))
 
-        content_type = ContentType.objects.get_by_natural_key(
-            *USER_NATURAL_KEY)
+        content_type = ContentType.objects.get_by_natural_key(*USER_NATURAL_KEY)
         admin_user_view = "admin:%s_%s_change" % (
             content_type.app_label,
             content_type.model,
         )
-        if (self.has_view_permission(request, obj)
-                and not self.has_change_permission(request, obj)):
+        if self.has_view_permission(request, obj) and not self.has_change_permission(
+            request, obj
+        ):
             title = _("View history: %s") % force_text(obj)
         else:
             title = _("Change history: %s") % force_text(obj)
@@ -265,16 +260,21 @@ class SimpleHistoryAdmin(HistoricalModelPermissionsAdminMixin, admin.ModelAdmin)
         )
 
     def history_view_title(self, request, obj):
-        return (_("Change history: %s") if self.has_change_permission(
-            request, obj) else _("View history: %s")) % force_text(obj)
+        return (
+            _("Change history: %s")
+            if self.has_change_permission(request, obj)
+            else _("View history: %s")
+        ) % force_text(obj)
 
     def history_form_view_title(self, request, obj):
-        return (_("Revert %s") if self.has_change_permission(
-            request, obj) else _('View %s')) % force_text(obj)
+        return (
+            _("Revert %s") if self.has_change_permission(request, obj) else _("View %s")
+        ) % force_text(obj)
 
     def show_close(self, request, obj):
-        return (not self.has_change_permission(request, obj)
-                and self.has_view_permission(request, obj))
+        return not self.has_change_permission(
+            request, obj
+        ) and self.has_view_permission(request, obj)
 
     def save_model(self, request, obj, form, change):
         """Set special model attribute to user for reference after save"""

--- a/simple_history/templates/simple_history/object_history.html
+++ b/simple_history/templates/simple_history/object_history.html
@@ -8,7 +8,9 @@
 {% block content %}
   <div id="content-main">
 
-    <p>{% blocktrans %}Choose a date from the list below to revert to a previous version of this object.{% endblocktrans %}</p>
+    {% if has_change_permission %}
+      <p>{% blocktrans %}Choose a date from the list below to revert to a previous version of this object.{% endblocktrans %}</p>
+    {% endif %}
 
     <div class="module">
       {% if action_list %}

--- a/simple_history/templates/simple_history/object_history_form.html
+++ b/simple_history/templates/simple_history/object_history_form.html
@@ -9,7 +9,11 @@
     <a href="{{changelist_url}}">{{opts.verbose_name_plural|capfirst}}</a> &rsaquo;
     <a href="{{change_url}}">{{original|truncatewords:"18"}}</a> &rsaquo;
     <a href="../">{% trans "History" %}</a> &rsaquo;
-    {% blocktrans with original_opts.verbose_name as verbose_name %}Revert {{verbose_name}}{% endblocktrans %}
+	{% if has_change_permission %}
+    	{% blocktrans with original_opts.verbose_name as verbose_name %}Revert {{verbose_name}}{% endblocktrans %}
+    {% else %}
+		{% blocktrans with original_opts.verbose_name as verbose_name %}{{verbose_name}}{% endblocktrans %}    
+   	{% endif %}
   </div>
 {% endblock %}
 
@@ -18,5 +22,7 @@
 {% endblock %}
 
 {% block form_top %}
+{% if has_change_permission %}
 <p>{% blocktrans %}Press the 'Revert' button below to revert to this version of the object.{% endblocktrans %} {% if change_history %}{% blocktrans %}Or press the 'Change History' button to edit the history.{% endblocktrans %}{% endif %}</p>
+{% endif %}
 {% endblock %}

--- a/simple_history/templates/simple_history/submit_line.html
+++ b/simple_history/templates/simple_history/submit_line.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <div class="submit-row">
 	{% if show_close %}<a href="{{ history_url }}" class="closelink">{% trans 'Close' %}</a>
-	{% elif show_revert %}
+	{% elif has_change_permission %}
 		<input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
 		{% if change_history %}<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>{% endif %}
 	{% endif %}

--- a/simple_history/templates/simple_history/submit_line.html
+++ b/simple_history/templates/simple_history/submit_line.html
@@ -1,5 +1,9 @@
 {% load i18n %}
 <div class="submit-row">
-<input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
+{% if has_change_permission %}
+	<input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
+{% else %}
+	<input type="submit" value="{% trans 'Close' %}" class="default" name="_close" {{ onclick_attrib }}/>
+{% endif %}
 {% if change_history %}<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>{% endif %}
 </div>

--- a/simple_history/templates/simple_history/submit_line.html
+++ b/simple_history/templates/simple_history/submit_line.html
@@ -1,9 +1,8 @@
 {% load i18n %}
 <div class="submit-row">
-{% if has_change_permission %}
-	<input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
-{% else %}
-	<input type="submit" value="{% trans 'Close' %}" class="default" name="_close" {{ onclick_attrib }}/>
-{% endif %}
-{% if change_history %}<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>{% endif %}
+	{% if show_close %}<a href="{{ history_url }}" class="closelink">{% trans 'Close' %}</a>
+	{% elif show_revert %}
+		<input type="submit" value="{% trans 'Revert' %}" class="default" name="_save" {{ onclick_attrib }}/>
+		{% if change_history %}<input type="submit" value="{% trans 'Change History' %}" class="default" name="_change_history" {{ onclick_attrib }}/>{% endif %}
+	{% endif %}
 </div>

--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -18,8 +18,7 @@ from .models import (
 
 
 class PersonAdmin(SimpleHistoryAdmin):
-    def has_change_permission(self, request, obj=None):
-        return False
+    pass
 
 
 class ChoiceAdmin(SimpleHistoryAdmin):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In some scenarios, it is not ideal to allow users to revert a model instance to a previous version. 
Django 2.1 introduced view permissions which, if integrated into DSH, would give an administrator the ability to allow a user to add/change a model but not revert to a previous instance through the models history.

## Description
<!--- Describe your changes in detail -->
The ``SimpleHistoryAdmin`` reviews the historical model instance permissions instead of just the model instance by overriding the has_xxxx_permission methods in ModelAdmin.

* permissions granted for the historical model cannot exceed those of the model. That is, granting "view" and "change" permissions for the historical model but only "view" permission for the model means the user has "view" permission only.

* the [Revert] button is changed to a [Close] button if the user only has "view_xxxx_permission" 

* For Django < 2.1, the view option is not relevant and DSH's behavior is unaffected

* other text on the changeless and form is hidden if the user has only "view" permission

## How Has This Been Tested?
mostly, still adding some tests ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.