### PR TITLE
Catch render() call, to allow overriding.

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -91,7 +91,9 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
-        return self.render_history_view(request, self.object_history_template, context, **extra_kwargs)
+        return self.render_history_view(
+            request, self.object_history_template, context, **extra_kwargs
+        )
 
     def response_change(self, request, obj):
         if "_change_history" in request.POST and SIMPLE_HISTORY_EDIT:
@@ -196,7 +198,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         return self.render_history_view(
             request, self.object_history_form_template, context, **extra_kwargs
         )
-    
+
     def render_history_view(self, *args, **kwargs):
         """Catch call to render, to allow overriding."""
         return render(*args, **kwargs)

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -193,9 +193,13 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
-        return render(
+        return self.render(
             request, self.object_history_form_template, context, **extra_kwargs
         )
+    
+    def render(*args, **kwargs):
+        """Catch call to render, to allow overriding."""
+        return render(*args, **kwargs)
 
     def save_model(self, request, obj, form, change):
         """Set special model attribute to user for reference after save"""

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -91,7 +91,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
-        return render(request, self.object_history_template, context, **extra_kwargs)
+        return self.indirect_render(request, self.object_history_template, context, **extra_kwargs)
 
     def response_change(self, request, obj):
         if "_change_history" in request.POST and SIMPLE_HISTORY_EDIT:
@@ -193,11 +193,11 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
-        return self.render(
+        return self.indirect_render(
             request, self.object_history_form_template, context, **extra_kwargs
         )
     
-    def render(self, *args, **kwargs):
+    def indirect_render(self, *args, **kwargs):
         """Catch call to render, to allow overriding."""
         return render(*args, **kwargs)
 

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -199,7 +199,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             request, self.object_history_form_template, context, **extra_kwargs
         )
 
-    def render_history_view(self, *args, **kwargs):
+    def render_history_view(self, request, template, context, **kwargs):
         """Catch call to render, to allow overriding."""
         return render(*args, **kwargs)
 

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -201,7 +201,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
 
     def render_history_view(self, request, template, context, **kwargs):
         """Catch call to render, to allow overriding."""
-        return render(*args, **kwargs)
+        return render(request, template, context, **kwargs)
 
     def save_model(self, request, obj, form, change):
         """Set special model attribute to user for reference after save"""

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -197,7 +197,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             request, self.object_history_form_template, context, **extra_kwargs
         )
     
-    def render(*args, **kwargs):
+    def render(self, *args, **kwargs):
         """Catch call to render, to allow overriding."""
         return render(*args, **kwargs)
 

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -91,7 +91,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
-        return self.indirect_render(request, self.object_history_template, context, **extra_kwargs)
+        return self.render_history_view(request, self.object_history_template, context, **extra_kwargs)
 
     def response_change(self, request, obj):
         if "_change_history" in request.POST and SIMPLE_HISTORY_EDIT:
@@ -193,11 +193,11 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(self.admin_site.each_context(request))
         context.update(extra_context or {})
         extra_kwargs = {}
-        return self.indirect_render(
+        return self.render_history_view(
             request, self.object_history_form_template, context, **extra_kwargs
         )
     
-    def indirect_render(self, *args, **kwargs):
+    def render_history_view(self, *args, **kwargs):
         """Catch call to render, to allow overriding."""
         return render(*args, **kwargs)
 


### PR DESCRIPTION
## Description
This PR changes a call in admin.py from being a direct call to `django.shortcuts.render` to being an indirect call, thereby allowing for the method to be overridden.

## Related Issue
N/A

## Motivation and Context
The problem being solved is flexibility with regards to overriding the default behavior of the admin view + form. Currently the only configuration points, are:
1. Providing additional context and overriding templates, or
2. Overriding `get_form / get_formset`, or
3. Overriding field defitinitions.

Adding the ability to override this one point, makes you able to change almost everything.
As the entire context is available, and one can simply provide any other required variables in the context, and clean them up again in the overridden render method.

The problem this solved for me, was the capability to change the generated form, not the form-class.

## How Has This Been Tested?
Not a lot of tests were needed, it's a simple indirection, but I have used it to change the generated form.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to change)

The change could potentially be changing for some users, assuming they have a method named indirect_render already.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
