### PR TITLE
added the possibility to create a relation to the original model

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,6 +67,7 @@ Authors
 - Mike Spainhower
 - Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
 - Nianpeng Li
+- Nick Träger
 - Phillip Marshall
 - Rajesh Pappula
 - Ray Logel
@@ -83,7 +84,6 @@ Authors
 - Trey Hunner (`treyhunner <https://github.com/treyhunner>`_)
 - Ulysses Vilela
 - `vnagendra <https://github.com/vnagendra>`_
-- Nick Träger
 
 Background
 ==========

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,6 +83,7 @@ Authors
 - Trey Hunner (`treyhunner <https://github.com/treyhunner>`_)
 - Ulysses Vilela
 - `vnagendra <https://github.com/vnagendra>`_
+- Nick Träger
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Changes
 
 - remove reference to vendored library ``django.utils.six`` in favor of ``six`` (gh-526)
 
+2.7.1 (2019-03-20)
+------------------
+- Added the possibility to create a relation to the original model
+
 2.7.0 (2019-01-16)
 ------------------
 - Add support for ``using`` chained manager method and save/delete keyword argument (gh-507)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@ Changes
 
 - remove reference to vendored library ``django.utils.six`` in favor of ``six`` (gh-526)
 
-2.7.1 (2019-03-20)
-------------------
+Unreleased
+----------
 - Added the possibility to create a relation to the original model
 
 2.7.0 (2019-01-16)

--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -147,3 +147,18 @@ If you want to save a model without a historical record, you can use the followi
 
     poll = Poll(question='something')
     poll.save_without_historical_record()
+
+
+Filtering data using a relationship to the model
+------------------------------------------------
+
+To filter changes to the data, a relationship to the history can be established. For example, all data records in which a particular user was involved.
+
+.. code-block:: python
+
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        log = HistoricalRecords(related_name='history')
+
+
+    Poll.objects.filter(history__history_user=4)

--- a/simple_history/exceptions.py
+++ b/simple_history/exceptions.py
@@ -13,3 +13,9 @@ class NotHistoricalModelError(TypeError):
     """No related history model found."""
 
     pass
+
+
+class RelatedNameConflictError(Exception):
+    """Related name conflicting with history manager"""
+
+    pass

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -326,8 +326,7 @@ class HistoricalRecords(object):
             return {
                 "history_relation": models.ForeignKey(
                     model,
-                    null=True,
-                    on_delete=models.SET_NULL,
+                    on_delete=models.DO_NOTHING,
                     related_name=self.related_name,
                     db_constraint=False,
                 )
@@ -454,7 +453,7 @@ class HistoricalRecords(object):
             attrs[field.attname] = getattr(instance, field.attname)
 
         relation_field = getattr(manager.model, "history_relation", None)
-        if relation_field is not None and history_type != "-":
+        if relation_field is not None:
             attrs["history_relation"] = instance
 
         history_instance = manager.model(

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -78,6 +78,7 @@ class HistoricalRecords(object):
         history_user_id_field=None,
         history_user_getter=_history_user_getter,
         history_user_setter=_history_user_setter,
+        related_name=None,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -93,6 +94,7 @@ class HistoricalRecords(object):
         self.user_id_field = history_user_id_field
         self.user_getter = history_user_getter
         self.user_setter = history_user_setter
+        self.related_name = related_name
 
         if excluded_fields is None:
             excluded_fields = []
@@ -315,6 +317,19 @@ class HistoricalRecords(object):
 
         return history_user_fields
 
+    def _get_history_related_field(self, model):
+        if self.related_name:
+            return {
+                "history_relation": models.ForeignKey(
+                    model,
+                    null=True,
+                    on_delete=models.SET_NULL,
+                    related_name=self.related_name,
+                )
+            }
+        else:
+            return {}
+
     def get_extra_fields(self, model, fields):
         """Return dict of extra fields added to the historical record model"""
 
@@ -387,6 +402,7 @@ class HistoricalRecords(object):
             ),
         }
 
+        extra_fields.update(self._get_history_related_field(model))
         extra_fields.update(self._get_history_user_fields())
 
         return extra_fields
@@ -431,6 +447,10 @@ class HistoricalRecords(object):
         attrs = {}
         for field in self.fields_included(instance):
             attrs[field.attname] = getattr(instance, field.attname)
+
+        relation_field = getattr(manager.model, 'history_relation', None)
+        if relation_field is not None:
+            attrs['history_relation'] = instance
 
         history_instance = manager.model(
             history_date=history_date,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -319,6 +319,10 @@ class HistoricalRecords(object):
 
     def _get_history_related_field(self, model):
         if self.related_name:
+            if self.manager_name == self.related_name:
+                raise exceptions.RelatedNameConflictError(
+                    "The related name must not be called like the history manager."
+                )
             return {
                 "history_relation": models.ForeignKey(
                     model,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -448,9 +448,9 @@ class HistoricalRecords(object):
         for field in self.fields_included(instance):
             attrs[field.attname] = getattr(instance, field.attname)
 
-        relation_field = getattr(manager.model, 'history_relation', None)
+        relation_field = getattr(manager.model, "history_relation", None)
         if relation_field is not None:
-            attrs['history_relation'] = instance
+            attrs["history_relation"] = instance
 
         history_instance = manager.model(
             history_date=history_date,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -329,6 +329,7 @@ class HistoricalRecords(object):
                     null=True,
                     on_delete=models.SET_NULL,
                     related_name=self.related_name,
+                    db_constraint=False,
                 )
             }
         else:
@@ -453,7 +454,7 @@ class HistoricalRecords(object):
             attrs[field.attname] = getattr(instance, field.attname)
 
         relation_field = getattr(manager.model, "history_relation", None)
-        if relation_field is not None:
+        if relation_field is not None and history_type != "-":
             attrs["history_relation"] = instance
 
         history_instance = manager.model(

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -571,4 +571,4 @@ class ForeignKeyToSelfModel(models.Model):
 
 class Street(models.Model):
     name = models.CharField(max_length=150)
-    log = HistoricalRecords(related_name='history')
+    log = HistoricalRecords(related_name="history")

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -567,3 +567,8 @@ class ForeignKeyToSelfModel(models.Model):
         "self", null=True, related_name="+", on_delete=models.CASCADE
     )
     history = HistoricalRecords()
+
+
+class Street(models.Model):
+    name = models.CharField(max_length=150)
+    log = HistoricalRecords(related_name='history')

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -15,6 +15,8 @@ from django.db.models.fields.proxy import OrderWrt
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from simple_history import register
+from simple_history.exceptions import RelatedNameConflictError
 from simple_history.models import HistoricalRecords, ModelChange
 from simple_history.signals import pre_create_historical_record
 from simple_history.tests.custom_user.models import CustomUser
@@ -1448,3 +1450,7 @@ class RelatedNameTest(TestCase):
         self.assertEqual(
             Street.objects.filter(history__history_user=self.user_two.pk).count(), 2
         )
+
+    def test_name_equals_manager(self):
+        with self.assertRaises(RelatedNameConflictError):
+            register(Place, manager_name="history", related_name="history")

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1468,9 +1468,13 @@ class RelatedNameTest(TestCase):
         self.assertEqual(
             Street.objects.filter(history__history_user=self.user_one.pk).count(), 0
         )
+        self.assertEqual(Street.objects.filter(pk=id).count(), 0)
 
         old = Street.log.filter(id=id).first()
         old.history_object.save()
         self.assertEqual(
             Street.objects.filter(history__history_user=self.user_one.pk).count(), 1
         )
+
+        self.one = Street.objects.get(pk=id)
+        self.assertEqual(self.one.history.count(), 4)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1425,15 +1425,15 @@ class RelatedNameTest(TestCase):
             username="username_two", email="second@user.com", password="top_secret"
         )
 
-        self.one = Street(name='Test Street')
+        self.one = Street(name="Test Street")
         self.one._history_user = self.user_one
         self.one.save()
 
-        self.two = Street(name='Sesame Street')
+        self.two = Street(name="Sesame Street")
         self.two._history_user = self.user_two
         self.two.save()
 
-        self.one.name = 'ABC Street'
+        self.one.name = "ABC Street"
         self.one._history_user = self.user_two
         self.one.save()
 
@@ -1442,7 +1442,9 @@ class RelatedNameTest(TestCase):
         self.assertEqual(self.two.history.count(), 1)
 
     def test_filter(self):
-        self.assertEqual(Street.objects.filter(
-            history__history_user=self.user_one.pk).count(), 1)
-        self.assertEqual(Street.objects.filter(
-            history__history_user=self.user_two.pk).count(), 2)
+        self.assertEqual(
+            Street.objects.filter(history__history_user=self.user_one.pk).count(), 1
+        )
+        self.assertEqual(
+            Street.objects.filter(history__history_user=self.user_two.pk).count(), 2
+        )

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1454,3 +1454,9 @@ class RelatedNameTest(TestCase):
     def test_name_equals_manager(self):
         with self.assertRaises(RelatedNameConflictError):
             register(Place, manager_name="history", related_name="history")
+
+    def test_deletion(self):
+        self.two.delete()
+
+        self.assertEqual(Street.log.filter(history_relation__isnull=True).count(), 2)
+        self.assertEqual(Street.log.count(), 4)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1458,5 +1458,5 @@ class RelatedNameTest(TestCase):
     def test_deletion(self):
         self.two.delete()
 
-        self.assertEqual(Street.log.filter(history_relation__isnull=True).count(), 2)
+        self.assertEqual(Street.log.filter(history_relation=2).count(), 2)
         self.assertEqual(Street.log.count(), 4)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1460,3 +1460,17 @@ class RelatedNameTest(TestCase):
 
         self.assertEqual(Street.log.filter(history_relation=2).count(), 2)
         self.assertEqual(Street.log.count(), 4)
+
+    def test_revert(self):
+        id = self.one.pk
+
+        self.one.delete()
+        self.assertEqual(
+            Street.objects.filter(history__history_user=self.user_one.pk).count(), 0
+        )
+
+        old = Street.log.filter(id=id).first()
+        old.history_object.save()
+        self.assertEqual(
+            Street.objects.filter(history__history_user=self.user_one.pk).count(), 1
+        )


### PR DESCRIPTION
## Description
i have created an optional parameter "related_name" which can be used to create another field "history_relation". This will then create a relation to the original entry.

## Related Issue
No related issue

## Motivation and Context
This should make filtering a little easier. For example, I can get all entries where a certain user has made changes.

## How Has This Been Tested?
Added some unit tests (RelatedNameTest)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.