### PR TITLE
Allow the use of multiple databases

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,6 +70,7 @@ Authors
 - Nianpeng Li
 - Nick Träger
 - Phillip Marshall
+- Prakash Venkatraman (`dopatraman <https://github.com/dopatraman>`_)
 - Rajesh Pappula
 - Ray Logel
 - Roberto Aguilar

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Unreleased
 ----------
 - Added the possibility to create a relation to the original model
 
+2.7.1 (2019-03-26)
+------------------
+- Added routing for saving historical records to separate databases if necessary.
+
 2.7.0 (2019-01-16)
 ------------------
 - Add support for ``using`` chained manager method and save/delete keyword argument (gh-507)

--- a/docs/multiple_dbs.rst
+++ b/docs/multiple_dbs.rst
@@ -39,3 +39,36 @@ an issue where you want to track the history on a table that lives in a separate
 database to your user model. Since Django does not support cross-database relations,
 you will have to manually track the ``history_user`` using an explicit ID. The full
 documentation on this feature is in :ref:`Manually Track User Model`.
+
+Migrating Historical Tables to Multiple Databases
+-------------------------------------------------
+If you want your historical records to live in separate databases, you will need
+to write a [database router](https://docs.djangoproject.com/en/2.1/topics/db/multi-db/#database-routers).
+The router interface requires 4 methods, but the only one that concerns us here
+is `allow_migrate`:
+```
+class DbRouter(object):
+    ...
+    def allow_migrate(self, db, app_label, model_name, **kwargs):
+        if self._is_history_db(db, app_label, model_name, kwargs):
+            return True
+        elif self._is_default_db(db, app_label, model_name, kwargs):
+            return True
+        else:
+            return False
+```
+Your `_is_history_db` method can be implemented however you like.
+
+Tracking History in a Separate Database
+---------------------------------------
+If you want to manage a historical model in separate database from its
+operational model, you may pass the `using` keyword to the `HistoricalRecords`
+constructor:
+```
+class MyModel(models.Model):
+    ...
+    history = HistoricalRecords(using='history_db')
+```
+
+As long as your historical table has been migrated to the `history_db`, you will
+be able to write to that database on every history event.

--- a/docs/multiple_dbs.rst
+++ b/docs/multiple_dbs.rst
@@ -72,3 +72,18 @@ class MyModel(models.Model):
 
 As long as your historical table has been migrated to the `history_db`, you will
 be able to write to that database on every history event.
+
+## Testing
+If you wish to test the existence of historical models in separate databases,
+you will need to add a Meta inner class:
+
+```
+class ModelWithHistoryInDifferentDb(models.Model):
+    name = models.CharField(max_length=30)
+    history = HistoricalRecords(using="other")
+
+    class Meta:
+        app_label = "external"
+```
+
+The app_label must be set to "external" for the migration to apply to the test database.

--- a/docs/multiple_dbs.rst
+++ b/docs/multiple_dbs.rst
@@ -40,50 +40,17 @@ database to your user model. Since Django does not support cross-database relati
 you will have to manually track the ``history_user`` using an explicit ID. The full
 documentation on this feature is in :ref:`Manually Track User Model`.
 
-Migrating Historical Tables to Multiple Databases
--------------------------------------------------
-If you want your historical records to live in separate databases, you will need
-to write a [database router](https://docs.djangoproject.com/en/2.1/topics/db/multi-db/#database-routers).
-The router interface requires 4 methods, but the only one that concerns us here
-is `allow_migrate`:
-```
-class DbRouter(object):
-    ...
-    def allow_migrate(self, db, app_label, model_name, **kwargs):
-        if self._is_history_db(db, app_label, model_name, kwargs):
-            return True
-        elif self._is_default_db(db, app_label, model_name, kwargs):
-            return True
-        else:
-            return False
-```
-Your `_is_history_db` method can be implemented however you like.
+Tracking History Separate from the Base Model
+---------------------------------------------
+You can choose whether or not to track models' history in the same database by
+setting the flag `use_base_model_db`.
 
-Tracking History in a Separate Database
----------------------------------------
-If you want to manage a historical model in separate database from its
-operational model, you may pass the `using` keyword to the `HistoricalRecords`
-constructor:
 ```
 class MyModel(models.Model):
     ...
-    history = HistoricalRecords(using='history_db')
+    history = HistoricalRecords(use_base_model_db=False)
 ```
 
-As long as your historical table has been migrated to the `history_db`, you will
-be able to write to that database on every history event.
-
-## Testing
-If you wish to test the existence of historical models in separate databases,
-you will need to add a Meta inner class:
-
-```
-class ModelWithHistoryInDifferentDb(models.Model):
-    name = models.CharField(max_length=30)
-    history = HistoricalRecords(using="other")
-
-    class Meta:
-        app_label = "external"
-```
-
-The app_label must be set to "external" for the migration to apply to the test database.
+If set to `True`, migrations and audit
+events will be sent to the same database as the base model. If `False`, they
+will be sent to the place specified by the database router.

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -79,6 +79,7 @@ class HistoricalRecords(object):
         history_user_getter=_history_user_getter,
         history_user_setter=_history_user_setter,
         related_name=None,
+        using=None,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -95,6 +96,7 @@ class HistoricalRecords(object):
         self.user_getter = history_user_getter
         self.user_setter = history_user_setter
         self.related_name = related_name
+        self.using = using
 
         if excluded_fields is None:
             excluded_fields = []
@@ -433,14 +435,14 @@ class HistoricalRecords(object):
         if not created and hasattr(instance, "skip_history_when_saving"):
             return
         if not kwargs.get("raw", False):
-            self.create_historical_record(instance, created and "+" or "~", using=(instance.history.db or using))
+            self.create_historical_record(instance, created and "+" or "~", using=(self.using or using))
 
     def post_delete(self, instance, using=None, **kwargs):
         if self.cascade_delete_history:
             manager = getattr(instance, self.manager_name)
             manager.using(using).all().delete()
         else:
-            self.create_historical_record(instance, "-", using=(instance.history.db or using))
+            self.create_historical_record(instance, "-", using=(self.using or using))
 
     def create_historical_record(self, instance, history_type, using=None):
         history_date = getattr(instance, "_history_date", now())

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -430,7 +430,6 @@ class HistoricalRecords(object):
         return meta_fields
 
     def post_save(self, instance, created, using=None, **kwargs):
-        print('post save called from simple history')
         if not created and hasattr(instance, "skip_history_when_saving"):
             return
         if not kwargs.get("raw", False):

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -430,17 +430,18 @@ class HistoricalRecords(object):
         return meta_fields
 
     def post_save(self, instance, created, using=None, **kwargs):
+        print('post save called from simple history')
         if not created and hasattr(instance, "skip_history_when_saving"):
             return
         if not kwargs.get("raw", False):
-            self.create_historical_record(instance, created and "+" or "~", using=using)
+            self.create_historical_record(instance, created and "+" or "~", using=(instance.history.db or using))
 
     def post_delete(self, instance, using=None, **kwargs):
         if self.cascade_delete_history:
             manager = getattr(instance, self.manager_name)
             manager.using(using).all().delete()
         else:
-            self.create_historical_record(instance, "-", using=using)
+            self.create_historical_record(instance, "-", using=(instance.history.db or using))
 
     def create_historical_record(self, instance, history_type, using=None):
         history_date = getattr(instance, "_history_date", now())

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -79,7 +79,7 @@ class HistoricalRecords(object):
         history_user_getter=_history_user_getter,
         history_user_setter=_history_user_setter,
         related_name=None,
-        use_base_table_db=True,
+        use_base_model_db=True,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -96,7 +96,7 @@ class HistoricalRecords(object):
         self.user_getter = history_user_getter
         self.user_setter = history_user_setter
         self.related_name = related_name
-        self.use_base_table_db = use_base_table_db
+        self.use_base_model_db = use_base_model_db
 
         if excluded_fields is None:
             excluded_fields = []
@@ -436,7 +436,7 @@ class HistoricalRecords(object):
             return
         if not kwargs.get("raw", False):
             self.create_historical_record(
-                instance, created and "+" or "~", using=using if self.use_base_table_db else None
+                instance, created and "+" or "~", using=using if self.use_base_model_db else None
             )
 
     def post_delete(self, instance, using=None, **kwargs):
@@ -444,7 +444,7 @@ class HistoricalRecords(object):
             manager = getattr(instance, self.manager_name)
             manager.using(using).all().delete()
         else:
-            self.create_historical_record(instance, "-", using=using if self.use_base_table_db else None)
+            self.create_historical_record(instance, "-", using=using if self.use_base_model_db else None)
 
     def create_historical_record(self, instance, history_type, using=None):
         history_date = getattr(instance, "_history_date", now())

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -79,7 +79,7 @@ class HistoricalRecords(object):
         history_user_getter=_history_user_getter,
         history_user_setter=_history_user_setter,
         related_name=None,
-        using=None,
+        use_base_table_db=True,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -96,7 +96,7 @@ class HistoricalRecords(object):
         self.user_getter = history_user_getter
         self.user_setter = history_user_setter
         self.related_name = related_name
-        self.using = using
+        self.use_base_table_db = use_base_table_db
 
         if excluded_fields is None:
             excluded_fields = []
@@ -436,7 +436,7 @@ class HistoricalRecords(object):
             return
         if not kwargs.get("raw", False):
             self.create_historical_record(
-                instance, created and "+" or "~", using=(self.using or using)
+                instance, created and "+" or "~", using=using if self.use_base_table_db else None
             )
 
     def post_delete(self, instance, using=None, **kwargs):
@@ -444,7 +444,7 @@ class HistoricalRecords(object):
             manager = getattr(instance, self.manager_name)
             manager.using(using).all().delete()
         else:
-            self.create_historical_record(instance, "-", using=(self.using or using))
+            self.create_historical_record(instance, "-", using=using if self.use_base_table_db else None)
 
     def create_historical_record(self, instance, history_type, using=None):
         history_date = getattr(instance, "_history_date", now())

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -436,7 +436,9 @@ class HistoricalRecords(object):
             return
         if not kwargs.get("raw", False):
             self.create_historical_record(
-                instance, created and "+" or "~", using=using if self.use_base_model_db else None
+                instance,
+                created and "+" or "~",
+                using=using if self.use_base_model_db else None,
             )
 
     def post_delete(self, instance, using=None, **kwargs):
@@ -444,7 +446,9 @@ class HistoricalRecords(object):
             manager = getattr(instance, self.manager_name)
             manager.using(using).all().delete()
         else:
-            self.create_historical_record(instance, "-", using=using if self.use_base_model_db else None)
+            self.create_historical_record(
+                instance, "-", using=using if self.use_base_model_db else None
+            )
 
     def create_historical_record(self, instance, history_type, using=None):
         history_date = getattr(instance, "_history_date", now())

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -435,7 +435,9 @@ class HistoricalRecords(object):
         if not created and hasattr(instance, "skip_history_when_saving"):
             return
         if not kwargs.get("raw", False):
-            self.create_historical_record(instance, created and "+" or "~", using=(self.using or using))
+            self.create_historical_record(
+                instance, created and "+" or "~", using=(self.using or using)
+            )
 
     def post_delete(self, instance, using=None, **kwargs):
         if self.cascade_delete_history:

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -366,6 +366,9 @@ class ModelWithHistoryInDifferentDb(models.Model):
     name = models.CharField(max_length=30)
     history = HistoricalRecords(using="other")
 
+    class Meta:
+        app_label = "external"
+
 
 ###############################################################################
 #

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -364,10 +364,7 @@ class ModelWithHistoryInDifferentApp(models.Model):
 
 class ModelWithHistoryInDifferentDb(models.Model):
     name = models.CharField(max_length=30)
-    history = HistoricalRecords(using="other")
-
-    class Meta:
-        app_label = "external"
+    history = HistoricalRecords(use_base_model_db=False)
 
 
 ###############################################################################

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -362,6 +362,11 @@ class ModelWithHistoryInDifferentApp(models.Model):
     history = HistoricalRecords(app="external")
 
 
+class ModelWithHistoryInDifferentDb(models.Model):
+    name = models.CharField(max_length=30)
+    history = HistoricalRecords(using="other")
+
+
 ###############################################################################
 #
 # Inheritance examples

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1493,10 +1493,15 @@ class UsingSeparateDatabaseTestCase(TestCase):
         self.user = get_user_model().objects.create(
             username="username", email="username@test.com", password="top_secret"
         )
-        self.model_ = ModelWithHistoryInDifferentDb(name="test")
-
-    def tearDown(self):
-        self.model_ = None
 
     def test_using_separate_db(self):
-        self.assertEqual("other", self.model_.history.db)
+        self.model_ = ModelWithHistoryInDifferentDb(name="test")
+        self.model_.save()
+        self.assertEqual("other", self.model_.history.using('other').db)
+        self.assertEqual(1, self.model_.history.using('other').count())
+        self.assertEqual("+", self.model_.history.using('other').first().history_type)
+        self.model_.name = "test1"
+        self.model_.save()
+        self.assertEqual("other", self.model_.history.using('other').db)
+        self.assertEqual(2, self.model_.history.using('other').count())
+        self.assertEqual("~", self.model_.history.using('other').first().history_type)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1482,9 +1482,12 @@ class RelatedNameTest(TestCase):
 
         self.one = Street.objects.get(pk=id)
         self.assertEqual(self.one.history.count(), 4)
+
+
 @override_settings(**database_router_override_settings)
 class UsingSeparateDatabaseTestCase(TestCase):
     multi_db = True
+    db_name = "other"
 
     def setUp(self):
         self.user = get_user_model().objects.create(

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1497,11 +1497,9 @@ class UsingSeparateDatabaseTestCase(TestCase):
     def test_using_separate_db(self):
         self.model_ = ModelWithHistoryInDifferentDb(name="test")
         self.model_.save()
-        self.assertEqual("other", self.model_.history.using('other').db)
-        self.assertEqual(1, self.model_.history.using('other').count())
-        self.assertEqual("+", self.model_.history.using('other').first().history_type)
+        self.assertEqual(1, self.model_.history.count())
+        self.assertEqual("+", self.model_.history.first().history_type)
         self.model_.name = "test1"
         self.model_.save()
-        self.assertEqual("other", self.model_.history.using('other').db)
-        self.assertEqual(2, self.model_.history.using('other').count())
-        self.assertEqual("~", self.model_.history.using('other').first().history_type)
+        self.assertEqual(2, self.model_.history.count())
+        self.assertEqual("~", self.model_.history.first().history_type)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1499,4 +1499,4 @@ class UsingSeparateDatabaseTestCase(TestCase):
         self.model_ = None
 
     def test_using_separate_db(self):
-        self.assertEqual("default", self.model_.history.db)
+        self.assertEqual("other", self.model_.history.db)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1484,6 +1484,8 @@ class RelatedNameTest(TestCase):
         self.assertEqual(self.one.history.count(), 4)
 @override_settings(**database_router_override_settings)
 class UsingSeparateDatabaseTestCase(TestCase):
+    multi_db = True
+
     def setUp(self):
         self.user = get_user_model().objects.create(
             username="username", email="username@test.com", password="top_secret"

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -30,8 +30,6 @@ class TestDbRouter(object):
         return None
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        print("db:", db)
-        print("model_name:", model_name)
         if app_label == "external":
             return db == "other"
         elif db == "other":

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -3,6 +3,10 @@ from django.conf import settings
 
 request_middleware = "simple_history.middleware.HistoryRequestMiddleware"
 
+WHITELIST = (
+    'historicalmodelwithhistoryindifferentdb',
+)
+
 if django.__version__ >= "2.0":
     middleware_override_settings = {
         "MIDDLEWARE": (settings.MIDDLEWARE + [request_middleware])
@@ -30,7 +34,8 @@ class TestDbRouter(object):
         return None
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        if app_label == "external":
+        print(db, model_name)
+        if app_label == "external" or model_name in WHITELIST:
             return db == "other"
         elif db == "other":
             return False

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -1,11 +1,11 @@
 import django
 from django.conf import settings
 
+from simple_history.tests.models import HistoricalModelWithHistoryInDifferentDb
+
 request_middleware = "simple_history.middleware.HistoryRequestMiddleware"
 
-WHITELIST = (
-    'historicalmodelwithhistoryindifferentdb',
-)
+OTHER_DB_NAME = "other"
 
 if django.__version__ >= "2.0":
     middleware_override_settings = {
@@ -20,12 +20,12 @@ else:
 class TestDbRouter(object):
     def db_for_read(self, model, **hints):
         if model._meta.app_label == "external":
-            return "other"
+            return OTHER_DB_NAME
         return None
 
     def db_for_write(self, model, **hints):
         if model._meta.app_label == "external":
-            return "other"
+            return OTHER_DB_NAME
         return None
 
     def allow_relation(self, obj1, obj2, **hints):
@@ -34,10 +34,9 @@ class TestDbRouter(object):
         return None
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
-        print(db, model_name)
-        if app_label == "external" or model_name in WHITELIST:
-            return db == "other"
-        elif db == "other":
+        if app_label == "external":
+            return db == OTHER_DB_NAME
+        elif db == OTHER_DB_NAME:
             return False
         else:
             return None
@@ -45,4 +44,35 @@ class TestDbRouter(object):
 
 database_router_override_settings = {
     "DATABASE_ROUTERS": ["simple_history.tests.tests.utils.TestDbRouter"]
+}
+
+
+class TestModelWithHistoryInDifferentDbRouter(object):
+    def db_for_read(self, model, **hints):
+        if model == HistoricalModelWithHistoryInDifferentDb:
+            return OTHER_DB_NAME
+        return None
+
+    def db_for_write(self, model, **hints):
+        if model == HistoricalModelWithHistoryInDifferentDb:
+            return OTHER_DB_NAME
+        return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        if isinstance(obj1, HistoricalModelWithHistoryInDifferentDb) or isinstance(
+            obj2, HistoricalModelWithHistoryInDifferentDb
+        ):
+            return False
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        if model_name == HistoricalModelWithHistoryInDifferentDb._meta.model_name:
+            return db == OTHER_DB_NAME
+        return None
+
+
+database_router_override_settings_history_in_diff_db = {
+    "DATABASE_ROUTERS": [
+        "simple_history.tests.tests.utils.TestModelWithHistoryInDifferentDbRouter"
+    ]
 }

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -30,6 +30,8 @@ class TestDbRouter(object):
         return None
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
+        print("db:", db)
+        print("model_name:", model_name)
         if app_label == "external":
             return db == "other"
         elif db == "other":


### PR DESCRIPTION
Right now, this library does not support saving historical to a database separate from its operational model. This PR allows the historical record to be saved to the same db as the historical record table.

## Description
- Save historical record to the database associated with the historical record table by passing in the db `alias` contained in the historical instance.

## Motivation and Context
As of now, the historical records are created using the database associated with the operational model being tracked, _not_ the database associated with the historical table. That means if the operational model is in a separate database, the library attempts to look up the historical table in the operational database, and subsequently fails.

## How Has This Been Tested?
So far, I have not been able to get the full test suite to run locally.

That being said, the tests involve creating a record on a second database by passing the db name into the `HistoricalRecords` constructor and then asserting its existence.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
