### PR TITLE
Patch bump for use_base_model_db -> 2.7.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.7.0
+current_version = 2.7.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 
 
 def register(


### PR DESCRIPTION
Specifying a new patch version for the changes in #539 

## Description
- Updated `setup.cfg`
- Updated `simple_history/__init__.py`

## Related PR
#539 

## Motivation and Context
The easiest way to reference the latest changeset from #539 would be a release tag.

## How Has This Been Tested?
AFAIK, no tests apart from the ones in #539 are necessary.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
