### PR TITLE
Fix non-backward compatible issue from 2.7.0 from GH-507

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 Unreleased
 ------------------
 - Added the possibility to create a relation to the original model (gh-536)
-- Fix router backward-compatibility issue with 2.7.0 (gh-539)
+- Fix router backward-compatibility issue with 2.7.0 (gh-539, gh-547)
 - Fix hardcoded history manager (gh-542)
 - Replace deprecated `django.utils.six` with `six` (gh-526)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,26 +1,26 @@
 Changes
 =======
 
-- remove reference to vendored library ``django.utils.six`` in favor of ``six`` (gh-526)
-- Fixed hardcoded history manager (gh-540)
-
 Unreleased
-----------
-- Added the possibility to create a relation to the original model
-
-2.7.1 (2019-03-26)
 ------------------
-- Added routing for saving historical records to separate databases if necessary.
+- Added the possibility to create a relation to the original model (gh-536)
+- Fix router backward-compatibility issue with 2.7.0 (gh-539)
+- Fix hardcoded history manager (gh-542)
+- Replace deprecated `django.utils.six` with `six` (gh-526)
 
 2.7.0 (2019-01-16)
 ------------------
-- Add support for ``using`` chained manager method and save/delete keyword argument (gh-507)
+- \* Add support for ``using`` chained manager method and save/delete keyword argument (gh-507)
 - Added management command ``clean_duplicate_history`` to remove duplicate history entries (gh-483)
 - Updated most_recent to work with excluded_fields (gh-477)
 - Fixed bug that prevented self-referential foreign key from using ``'self'`` (gh-513)
 - Added ability to track custom user with explicit custom ``history_user_id_field`` (gh-511)
 - Don't resolve relationships for history objects (gh-479)
 - Reorganization of docs (gh-510)
+
+\* NOTE: This change was not backward compatible for users using routers to write
+history tables to a separate database from their base tables. This issue is fixed in
+2.7.1.
 
 2.6.0 (2018-12-12)
 ------------------

--- a/docs/multiple_dbs.rst
+++ b/docs/multiple_dbs.rst
@@ -53,4 +53,4 @@ class MyModel(models.Model):
 
 If set to `True`, migrations and audit
 events will be sent to the same database as the base model. If `False`, they
-will be sent to the place specified by the database router.
+will be sent to the place specified by the database router. The default value is `False`.

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -79,7 +79,7 @@ class HistoricalRecords(object):
         history_user_getter=_history_user_getter,
         history_user_setter=_history_user_setter,
         related_name=None,
-        use_base_model_db=True,
+        use_base_model_db=False,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -364,7 +364,19 @@ class ModelWithHistoryInDifferentApp(models.Model):
 
 class ModelWithHistoryInDifferentDb(models.Model):
     name = models.CharField(max_length=30)
-    history = HistoricalRecords(use_base_model_db=False)
+    history = HistoricalRecords()
+
+
+class ModelWithHistoryUseBaseModelDb(models.Model):
+    name = models.CharField(max_length=30)
+    history = HistoricalRecords(use_base_model_db=True)
+
+
+class ModelWithFkToModelWithHistoryUseBaseModelDb(models.Model):
+    fk = models.ForeignKey(
+        ModelWithHistoryUseBaseModelDb, on_delete=models.CASCADE, null=True
+    )
+    history = HistoricalRecords(use_base_model_db=True)
 
 
 ###############################################################################

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -367,14 +367,14 @@ class ModelWithHistoryInDifferentDb(models.Model):
     history = HistoricalRecords()
 
 
-class ModelWithHistoryUseBaseModelDb(models.Model):
+class ModelWithHistoryUsingBaseModelDb(models.Model):
     name = models.CharField(max_length=30)
     history = HistoricalRecords(use_base_model_db=True)
 
 
-class ModelWithFkToModelWithHistoryUseBaseModelDb(models.Model):
+class ModelWithFkToModelWithHistoryUsingBaseModelDb(models.Model):
     fk = models.ForeignKey(
-        ModelWithHistoryUseBaseModelDb, on_delete=models.CASCADE, null=True
+        ModelWithHistoryUsingBaseModelDb, on_delete=models.CASCADE, null=True
     )
     history = HistoricalRecords(use_base_model_db=True)
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
 import unittest
-
-import django
 import uuid
 import warnings
 from datetime import datetime, timedelta
+
+import django
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
@@ -18,22 +18,19 @@ from django.urls import reverse
 from simple_history import register
 from simple_history.exceptions import RelatedNameConflictError
 from simple_history.models import HistoricalRecords, ModelChange
-from simple_history.signals import (
-    pre_create_historical_record,
-    post_create_historical_record,
-)
+from simple_history.signals import pre_create_historical_record
 from simple_history.tests.custom_user.models import CustomUser
 from simple_history.tests.tests.utils import (
     database_router_override_settings,
-    middleware_override_settings,
     database_router_override_settings_history_in_diff_db,
+    middleware_override_settings,
 )
 from simple_history.utils import get_history_model_for_model
 from simple_history.utils import update_change_reason
 from ..external.models import (
     ExternalModel,
-    ExternalModelWithCustomUserIdField,
     ExternalModelRegistered,
+    ExternalModelWithCustomUserIdField,
 )
 from ..models import (
     AbstractBase,
@@ -66,7 +63,9 @@ from ..models import (
     HistoricalPollWithHistoricalIPAddress,
     HistoricalState,
     Library,
+    ModelWithFkToModelWithHistoryUseBaseModelDb,
     ModelWithHistoryInDifferentDb,
+    ModelWithHistoryUseBaseModelDb,
     MultiOneToOne,
     Person,
     Place,
@@ -1262,78 +1261,98 @@ class MultiDBWithUsingTest(TestCase):
     db_name = "other"
 
     def test_multidb_with_using_not_on_default(self):
-        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
-        self.assertRaises(ObjectDoesNotExist, book.history.get, isbn="1-84356-028-1")
+        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+            name="1-84356-028-1"
+        )
+        self.assertRaises(ObjectDoesNotExist, model.history.get, name="1-84356-028-1")
 
     def test_multidb_with_using_is_on_dbtwo(self):
-        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
+        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+            name="1-84356-028-1"
+        )
         try:
-            book.history.using(self.db_name).get(isbn="1-84356-028-1")
+            model.history.using(self.db_name).get(name="1-84356-028-1")
         except ObjectDoesNotExist:
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_and_fk_not_on_default(self):
-        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
-        library = Library.objects.using(self.db_name).create(book=book)
-        self.assertRaises(ObjectDoesNotExist, library.history.get, book=book)
+        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+            name="1-84356-028-1"
+        )
+        parent_model = ModelWithFkToModelWithHistoryUseBaseModelDb.objects.using(
+            self.db_name
+        ).create(fk=model)
+        self.assertRaises(ObjectDoesNotExist, parent_model.history.get, fk=model)
 
     def test_multidb_with_using_and_fk_on_dbtwo(self):
-        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
-        library = Library.objects.using(self.db_name).create(book=book)
+        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+            name="1-84356-028-1"
+        )
+        parent_model = ModelWithFkToModelWithHistoryUseBaseModelDb.objects.using(
+            self.db_name
+        ).create(fk=model)
         try:
-            library.history.using(self.db_name).get(book=book)
+            parent_model.history.using(self.db_name).get(fk=model)
         except ObjectDoesNotExist:
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_not_on_default(self):
-        book = Book(isbn="1-84356-028-1")
-        book.save(using=self.db_name)
-        self.assertRaises(ObjectDoesNotExist, book.history.get, isbn="1-84356-028-1")
+        model = ModelWithHistoryUseBaseModelDb(name="1-84356-028-1")
+        model.save(using=self.db_name)
+        self.assertRaises(ObjectDoesNotExist, model.history.get, name="1-84356-028-1")
 
     def test_multidb_with_using_keyword_in_save_on_dbtwo(self):
-        book = Book(isbn="1-84356-028-1")
-        book.save(using=self.db_name)
+        model = ModelWithHistoryUseBaseModelDb(name="1-84356-028-1")
+        model.save(using=self.db_name)
         try:
-            book.history.using(self.db_name).get(isbn="1-84356-028-1")
+            model.history.using(self.db_name).get(name="1-84356-028-1")
         except ObjectDoesNotExist:
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_with_fk(self):
-        book = Book(isbn="1-84356-028-1")
-        book.save(using=self.db_name)
-        library = Library(book=book)
-        library.save(using=self.db_name)
+        model = ModelWithHistoryUseBaseModelDb(name="1-84356-028-1")
+        model.save(using=self.db_name)
+        parent_model = ModelWithFkToModelWithHistoryUseBaseModelDb(fk=model)
+        parent_model.save(using=self.db_name)
         # assert not created on default
-        self.assertRaises(ObjectDoesNotExist, library.history.get, book=book)
+        self.assertRaises(ObjectDoesNotExist, parent_model.history.get, fk=model)
         # assert created on dbtwo
         try:
-            library.history.using(self.db_name).get(book=book)
+            parent_model.history.using(self.db_name).get(fk=model)
         except ObjectDoesNotExist:
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_and_update(self):
-        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
-        book.save(using=self.db_name)
+        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+            name="1-84356-028-1"
+        )
+        model.save(using=self.db_name)
         self.assertEqual(
             ["+", "~"],
             [
                 obj.history_type
-                for obj in book.history.using(self.db_name)
+                for obj in model.history.using(self.db_name)
                 .all()
                 .order_by("history_date")
             ],
         )
 
     def test_multidb_with_using_keyword_in_save_and_delete(self):
-        HistoricalBook = get_history_model_for_model(Book)
-        book = Book.objects.using(self.db_name).create(isbn="1-84356-028-1")
-        book.save(using=self.db_name)
-        book.delete(using=self.db_name)
+        HistoricalModelWithHistoryUseBaseModelDb = get_history_model_for_model(
+            ModelWithHistoryUseBaseModelDb
+        )
+        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+            name="1-84356-028-1"
+        )
+        model.save(using=self.db_name)
+        model.delete(using=self.db_name)
         self.assertEqual(
             ["+", "~", "-"],
             [
                 obj.history_type
-                for obj in HistoricalBook.objects.using(self.db_name)
+                for obj in HistoricalModelWithHistoryUseBaseModelDb.objects.using(
+                    self.db_name
+                )
                 .all()
                 .order_by("history_date")
             ],

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -63,9 +63,9 @@ from ..models import (
     HistoricalPollWithHistoricalIPAddress,
     HistoricalState,
     Library,
-    ModelWithFkToModelWithHistoryUseBaseModelDb,
+    ModelWithFkToModelWithHistoryUsingBaseModelDb,
     ModelWithHistoryInDifferentDb,
-    ModelWithHistoryUseBaseModelDb,
+    ModelWithHistoryUsingBaseModelDb,
     MultiOneToOne,
     Person,
     Place,
@@ -1261,13 +1261,13 @@ class MultiDBWithUsingTest(TestCase):
     db_name = "other"
 
     def test_multidb_with_using_not_on_default(self):
-        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+        model = ModelWithHistoryUsingBaseModelDb.objects.using(self.db_name).create(
             name="1-84356-028-1"
         )
         self.assertRaises(ObjectDoesNotExist, model.history.get, name="1-84356-028-1")
 
     def test_multidb_with_using_is_on_dbtwo(self):
-        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+        model = ModelWithHistoryUsingBaseModelDb.objects.using(self.db_name).create(
             name="1-84356-028-1"
         )
         try:
@@ -1276,19 +1276,19 @@ class MultiDBWithUsingTest(TestCase):
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_and_fk_not_on_default(self):
-        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+        model = ModelWithHistoryUsingBaseModelDb.objects.using(self.db_name).create(
             name="1-84356-028-1"
         )
-        parent_model = ModelWithFkToModelWithHistoryUseBaseModelDb.objects.using(
+        parent_model = ModelWithFkToModelWithHistoryUsingBaseModelDb.objects.using(
             self.db_name
         ).create(fk=model)
         self.assertRaises(ObjectDoesNotExist, parent_model.history.get, fk=model)
 
     def test_multidb_with_using_and_fk_on_dbtwo(self):
-        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+        model = ModelWithHistoryUsingBaseModelDb.objects.using(self.db_name).create(
             name="1-84356-028-1"
         )
-        parent_model = ModelWithFkToModelWithHistoryUseBaseModelDb.objects.using(
+        parent_model = ModelWithFkToModelWithHistoryUsingBaseModelDb.objects.using(
             self.db_name
         ).create(fk=model)
         try:
@@ -1297,12 +1297,12 @@ class MultiDBWithUsingTest(TestCase):
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_not_on_default(self):
-        model = ModelWithHistoryUseBaseModelDb(name="1-84356-028-1")
+        model = ModelWithHistoryUsingBaseModelDb(name="1-84356-028-1")
         model.save(using=self.db_name)
         self.assertRaises(ObjectDoesNotExist, model.history.get, name="1-84356-028-1")
 
     def test_multidb_with_using_keyword_in_save_on_dbtwo(self):
-        model = ModelWithHistoryUseBaseModelDb(name="1-84356-028-1")
+        model = ModelWithHistoryUsingBaseModelDb(name="1-84356-028-1")
         model.save(using=self.db_name)
         try:
             model.history.using(self.db_name).get(name="1-84356-028-1")
@@ -1310,9 +1310,9 @@ class MultiDBWithUsingTest(TestCase):
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_with_fk(self):
-        model = ModelWithHistoryUseBaseModelDb(name="1-84356-028-1")
+        model = ModelWithHistoryUsingBaseModelDb(name="1-84356-028-1")
         model.save(using=self.db_name)
-        parent_model = ModelWithFkToModelWithHistoryUseBaseModelDb(fk=model)
+        parent_model = ModelWithFkToModelWithHistoryUsingBaseModelDb(fk=model)
         parent_model.save(using=self.db_name)
         # assert not created on default
         self.assertRaises(ObjectDoesNotExist, parent_model.history.get, fk=model)
@@ -1323,7 +1323,7 @@ class MultiDBWithUsingTest(TestCase):
             self.fail("ObjectDoesNotExist unexpectedly raised.")
 
     def test_multidb_with_using_keyword_in_save_and_update(self):
-        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+        model = ModelWithHistoryUsingBaseModelDb.objects.using(self.db_name).create(
             name="1-84356-028-1"
         )
         model.save(using=self.db_name)
@@ -1339,9 +1339,9 @@ class MultiDBWithUsingTest(TestCase):
 
     def test_multidb_with_using_keyword_in_save_and_delete(self):
         HistoricalModelWithHistoryUseBaseModelDb = get_history_model_for_model(
-            ModelWithHistoryUseBaseModelDb
+            ModelWithHistoryUsingBaseModelDb
         )
-        model = ModelWithHistoryUseBaseModelDb.objects.using(self.db_name).create(
+        model = ModelWithHistoryUsingBaseModelDb.objects.using(self.db_name).create(
             name="1-84356-028-1"
         )
         model.save(using=self.db_name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#507 introduced a non-backward compatible change to DSH 2.7.0. The change affects users that were using routers beforehand to write their history models to databases other than their base models' db. #536 fixed the issue, but made it backward compatible with 2.7.0. Since then, we decided to make this next version (2.7.1) backward compatible with versions pre-2.7.0, since what was introduced in #507 was a bug. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
