### PR TITLE
Patch for ModuleNotFound issue with `six`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+2.7.2 (2019-04-17)
+------------------
+- Fixed ModuleNotFound issue for `six`
+
 2.7.1 (2019-04-16)
 ------------------
 - Added the possibility to create a relation to the original model (gh-536)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes
 
 2.7.2 (2019-04-17)
 ------------------
-- Fixed ModuleNotFound issue for `six`
+- Fixed ModuleNotFound issue for `six` (gh-553)
 
 2.7.1 (2019-04-16)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.7.1
+current_version = 2.7.2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import simple_history
 
 tests_require = [
     'Django>=1.11', 'WebTest==2.0.24', 'django-webtest==1.8.0', 'mock==1.0.1',
-    'six>=1.3.0']
+    'six']
 
 setup(
     name='django-simple-history',
@@ -40,7 +40,7 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     tests_require=tests_require,
-    install_requires=["six>=1.3.0"],
+    install_requires=["six"],
     include_package_data=True,
     test_suite='runtests.main',
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import simple_history
 
 tests_require = [
     'Django>=1.11', 'WebTest==2.0.24', 'django-webtest==1.8.0', 'mock==1.0.1',
-    'six==1.12.0']
+    'six>=1.3.0']
 
 setup(
     name='django-simple-history',
@@ -40,7 +40,7 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     tests_require=tests_require,
-    install_requires=["six==1.12.0"],
+    install_requires=["six>=1.3.0"],
     include_package_data=True,
     test_suite='runtests.main',
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup
 import simple_history
 
 tests_require = [
-    'Django>=1.11', 'WebTest==2.0.24', 'django-webtest==1.8.0', 'mock==1.0.1']
+    'Django>=1.11', 'WebTest==2.0.24', 'django-webtest==1.8.0', 'mock==1.0.1',
+    'six==1.12.0']
 
 setup(
     name='django-simple-history',
@@ -39,6 +40,7 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     tests_require=tests_require,
+    install_requires=["six==1.12.0"],
     include_package_data=True,
     test_suite='runtests.main',
 )

--- a/simple_history/__init__.py
+++ b/simple_history/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 
 def register(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In #526 we removed `django.utils.six` since it's deprecated, but forgot to include `six` as an `install_requires` dependency on the library. Thus, users using DSH 2.7.1 who did not have `six` installed received a `ModuleNotFound` error. This PR includes `six` as an `install_requires` dependency and bumps the version to 2.7.2 to that we can get the fix out. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #552 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
