### PR TITLE
BigAutoField not mirrored as bigint in historical copy of table #556

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Changes
 =======
 
+Unreleased
+----------
+- Fixed BigAutoField not mirrored as BigInt (gh-556)
 - Fixed most_recent() bug with excluded_fields (gh-561)
 
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -549,6 +549,7 @@ def transform_field(field):
         field.db_index = True
         field.serialize = True
 
+        
 class HistoricalObjectDescriptor(object):
     def __init__(self, model, fields_included):
         self.model = model

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -549,7 +549,7 @@ def transform_field(field):
         field.db_index = True
         field.serialize = True
 
-        
+
 class HistoricalObjectDescriptor(object):
     def __init__(self, model, fields_included):
         self.model = model

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -528,7 +528,9 @@ class HistoricalRecords(object):
 def transform_field(field):
     """Customize field appropriately for use in historical model"""
     field.name = field.attname
-    if isinstance(field, models.AutoField):
+    if isinstance(field, models.BigAutoField):
+        field.__class__ = models.BigIntegerField
+    elif isinstance(field, models.AutoField):
         field.__class__ = models.IntegerField
 
     elif isinstance(field, models.FileField):
@@ -546,7 +548,6 @@ def transform_field(field):
         field._unique = False
         field.db_index = True
         field.serialize = True
-
 
 class HistoricalObjectDescriptor(object):
     def __init__(self, model, fields_included):


### PR DESCRIPTION
BigAutoField not mirrored as bigint in historical copy of table #556
--credit to tomj74's changes 
<!--- Provide a general summary of your changes in the Title above -->

## Description
If BigAutoField is used in a model, this is not correctly interpreted as a BigInt, but rather as an Integer.  When BigAutoField exceeds the maximum value of Integer, this will cause a database error and break the application.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
BigAutoField not mirrored as bigint in historical copy of table #556
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Any usage of BigAutoField is potentially broken depending on the current value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Rolled into application that extensively uses BigAutoField with sequence values exceeding Integer maximum value. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
