### PR TITLE
Fixed bug in most_recent() where excluded_fields weren't handled correctly

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Authors
 - Adnan Umer (`uadnan <https://github.com/uadnan>`_)
 - Aleksey Kladov
 - Alexander Anikeev
+- Amanda Ng (`AmandaCLNg <https://github.com/AmandaCLNg>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - `bradford281 <https://github.com/bradford281>`_
 - Brian Armstrong (`barm <https://github.com/barm>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Changes
 =======
 
+- Fixed most_recent() bug with excluded_fields (gh-561)
+
+
 2.7.2 (2019-04-17)
 ------------------
 - Fixed ModuleNotFound issue for `six` (gh-553)

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -56,12 +56,12 @@ class HistoryManager(models.Manager):
                 tmp.append(field.name)
         fields = tuple(tmp)
         try:
-            values = self.get_queryset().values_list(*fields)[0]
+            values = self.get_queryset().values(*fields)[0]
         except IndexError:
             raise self.instance.DoesNotExist(
                 "%s has no historical record." % self.instance._meta.object_name
             )
-        return self.instance.__class__(*values)
+        return self.instance.__class__(**values)
 
     def as_of(self, date):
         """Get a snapshot as of a specific date.

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -30,6 +30,7 @@ class Poll(models.Model):
 class PollWithExcludeFields(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField("date published")
+    place = models.TextField(null=True)
 
     history = HistoricalRecords(excluded_fields=["pub_date"])
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -463,18 +463,22 @@ class HistoricalRecordsTest(TestCase):
         poll_info.save()
 
     def test_model_with_excluded_fields(self):
-        p = PollWithExcludeFields(question="what's up?", pub_date=today)
+        p = PollWithExcludeFields(question="what's up?", pub_date=today, place='The Pub')
         p.save()
         history = PollWithExcludeFields.history.all()[0]
         all_fields_names = [f.name for f in history._meta.fields]
         self.assertIn("question", all_fields_names)
         self.assertNotIn("pub_date", all_fields_names)
+        self.assertEqual(history.question, p.question)
+        self.assertEqual(history.place, p.place)
 
         most_recent = p.history.most_recent()
         self.assertIn("question", all_fields_names)
         self.assertNotIn("pub_date", all_fields_names)
         self.assertEqual(most_recent.__class__, PollWithExcludeFields)
         self.assertIn("pub_date", history._history_excluded_fields)
+        self.assertEqual(most_recent.question, p.question)
+        self.assertEqual(most_recent.place, p.place)
 
     def test_user_model_override(self):
         user1 = User.objects.create_user("user1", "1@example.com")

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -463,7 +463,9 @@ class HistoricalRecordsTest(TestCase):
         poll_info.save()
 
     def test_model_with_excluded_fields(self):
-        p = PollWithExcludeFields(question="what's up?", pub_date=today, place='The Pub')
+        p = PollWithExcludeFields(
+            question="what's up?", pub_date=today, place="The Pub"
+        )
         p.save()
         history = PollWithExcludeFields.history.all()[0]
         all_fields_names = [f.name for f in history._meta.fields]

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -17,6 +17,13 @@ class BulkCreateWithHistoryTestCase(TestCase):
             Poll(id=4, question="Question 4", pub_date=now()),
             Poll(id=5, question="Question 5", pub_date=now()),
         ]
+        self.data_with_excluded_fields = [
+            PollWithExcludeFields(id=1, question="Question 1", pub_date=now()),
+            PollWithExcludeFields(id=2, question="Question 2", pub_date=now()),
+            PollWithExcludeFields(id=3, question="Question 3", pub_date=now()),
+            PollWithExcludeFields(id=4, question="Question 4", pub_date=now()),
+            PollWithExcludeFields(id=5, question="Question 5", pub_date=now()),
+        ]
 
     def test_bulk_create_history(self):
         bulk_create_with_history(self.data, Poll)
@@ -48,7 +55,7 @@ class BulkCreateWithHistoryTestCase(TestCase):
         self.assertEqual(Poll.history.count(), 5)
 
     def test_bulk_create_works_with_excluded_fields(self):
-        bulk_create_with_history(self.data, PollWithExcludeFields)
+        bulk_create_with_history(self.data_with_excluded_fields, PollWithExcludeFields)
 
         self.assertEqual(Poll.objects.count(), 0)
         self.assertEqual(Poll.history.count(), 0)


### PR DESCRIPTION
Bug fix for most_recent() method when excluded field is not last field in model definition

## Description
- changed lines 59 and 64 in manager.py:most_recent() to retrieve field/value dictionary instead of just values, and use the dictionary to initialise the class instance

## Related Issue
#561 

## Motivation and Context
 Why is this change required? Because there is a bug.
What problem does it solve? The bug (see #561 )

## How Has This Been Tested?
Yes - test code has been updated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation. - NOT REQUIRED
- [ ] I have updated the documentation accordingly. - NOT REQUIRED
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.

(PS Apologies if I haven't done something correctly - first time contributing to another package)