### PR TITLE
Fixed error when trying to get instance if object is deleted #571

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,6 +87,7 @@ Authors
 - Trey Hunner (`treyhunner <https://github.com/treyhunner>`_)
 - Ulysses Vilela
 - `vnagendra <https://github.com/vnagendra>`_
+- `yakimka <https://github.com/yakimka>`_
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+----------
+- Fixed DoesNotExist error when trying to get instance if object is deleted (gh-571)
+
 2.7.3 (2019-07-15)
 ------------------
 - Fixed BigAutoField not mirrored as BigInt (gh-556)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -375,20 +375,20 @@ class HistoricalRecords(object):
                 field.attname: getattr(self, field.attname) for field in fields.values()
             }
             if self._history_excluded_fields:
-                excluded_attnames_defaults = {}
-                for field_name in self._history_excluded_fields:
-                    field = model._meta.get_field(field_name)
-                    excluded_attnames_defaults[field.attname] = field.get_default()
-
+                excluded_attnames = [
+                    model._meta.get_field(field).attname
+                    for field in self._history_excluded_fields
+                ]
                 try:
                     values = (
                         model.objects.filter(pk=getattr(self, model._meta.pk.attname))
-                        .values(*excluded_attnames_defaults.keys())
+                        .values(*excluded_attnames)
                         .get()
                     )
                 except ObjectDoesNotExist:
-                    values = excluded_attnames_defaults
-                attrs.update(values)
+                    pass
+                else:
+                    attrs.update(values)
             return model(**attrs)
 
         def get_next_record(self):

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import datetime
 import uuid
 from django.apps import apps
 from django.conf import settings
@@ -33,6 +34,25 @@ class PollWithExcludeFields(models.Model):
     place = models.TextField(null=True)
 
     history = HistoricalRecords(excluded_fields=["pub_date"])
+
+
+class PollWithExcludedFieldsWithDefaults(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    expiration_time = models.DateField(default=datetime.date(2030, 12, 12))
+    place = models.TextField(null=True)
+    min_questions = models.PositiveIntegerField(default=1)
+    max_questions = models.PositiveIntegerField()
+
+    history = HistoricalRecords(
+        excluded_fields=[
+            "pub_date",
+            "expiration_time",
+            "place",
+            "min_questions",
+            "max_questions",
+        ]
+    )
 
 
 class PollWithExcludedFKField(models.Model):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1185,6 +1185,18 @@ class ExcludeFieldsTest(TestCase):
         original = historical.instance
         self.assertEqual(original.pub_date, poll.pub_date)
 
+    def test_get_default_values_for_excluded_fields(self):
+        poll = PollWithExcludeFields.objects.create(
+            question="what's up?", pub_date=today
+        )
+        historical = poll.history.order_by("pk")[0]
+        poll.delete()
+        original = historical.instance
+        self.assertEqual(
+            original.pub_date,
+            PollWithExcludeFields._meta.get_field("pub_date").get_default(),
+        )
+
 
 class ExcludeForeignKeyTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixed DoesNotExist error when trying to get instance if object is deleted

## Description
- changed `get_instance` method to retrieve attname and default value for field instead of only attname

## Related Issue
#571

## Motivation and Context
This change required because i think this is a bug.
It solve error when trying to get `instance`, `prev_record` or `next_record` when object is deleted

## How Has This Been Tested?
Run tests locally and updated test code

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
