### PR TITLE
fix #575 use django model_to_dict to detect changes in parent models

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -58,6 +58,7 @@ Authors
 - Leticia Portella
 - Lucas Wiman
 - Maciej "RooTer" Urbański
+- Marcelo Canina (`marcanuy <https://github.com/marcanuy>`_)
 - Mark Davidoff
 - Martin Bachwerk
 - Marty Alchin

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 Unreleased
 ----------
 - Fixed DoesNotExist error when trying to get instance if object is deleted (gh-571)
+- Use Django's `model_to_dict` instead of a custom implementation so
+  it detect changes in a parent model when using `inherit=True`
+  (gh-576)
 
 2.7.3 (2019-07-15)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,9 @@ Changes
 Unreleased
 ----------
 - Fixed DoesNotExist error when trying to get instance if object is deleted (gh-571)
-- Use Django's `model_to_dict` instead of a custom implementation so
-  it detect changes in a parent model when using `inherit=True`
-  (gh-576)
+- Fix `model_to_dict` to detect changes in a parent model when using
+  `inherit=True` (backwards-incompatible for users who were directly
+  using previous version) (gh-576)
 
 2.7.3 (2019-07-15)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -16,6 +16,7 @@ from django.core.serializers import serialize
 from django.db import models
 from django.db.models import Q
 from django.db.models.fields.proxy import OrderWrt
+from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible, smart_text
 from django.utils.text import format_lazy
@@ -30,10 +31,6 @@ from .signals import post_create_historical_record, pre_create_historical_record
 import json
 
 registered_models = {}
-
-
-def _model_to_dict(model):
-    return json.loads(serialize("json", [model]))[0]["fields"]
 
 
 def _default_get_user(request, **kwargs):
@@ -576,8 +573,8 @@ class HistoricalChanges(object):
 
         changes = []
         changed_fields = []
-        old_values = _model_to_dict(old_history.instance)
-        current_values = _model_to_dict(self.instance)
+        old_values = model_to_dict(old_history.instance)
+        current_values = model_to_dict(self.instance)
         for field, new_value in current_values.items():
             if field in old_values:
                 old_value = old_values[field]

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -482,6 +482,14 @@ class InheritTracking3(BaseInheritTracking3):
 class InheritTracking4(TrackedAbstractBaseA):
     pass
 
+class BasePlace(models.Model):
+    name = models.CharField(max_length=50)
+    history = HistoricalRecords(
+        inherit=True,
+    ) 
+
+class InheritedRestaurant(BasePlace):
+    serves_hot_dogs = models.BooleanField(default=False)
 
 class BucketMember(models.Model):
     name = models.CharField(max_length=30)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -482,14 +482,17 @@ class InheritTracking3(BaseInheritTracking3):
 class InheritTracking4(TrackedAbstractBaseA):
     pass
 
+
 class BasePlace(models.Model):
     name = models.CharField(max_length=50)
     history = HistoricalRecords(
         inherit=True,
-    ) 
+    )
+
 
 class InheritedRestaurant(BasePlace):
     serves_hot_dogs = models.BooleanField(default=False)
+
 
 class BucketMember(models.Model):
     name = models.CharField(max_length=30)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -485,9 +485,7 @@ class InheritTracking4(TrackedAbstractBaseA):
 
 class BasePlace(models.Model):
     name = models.CharField(max_length=50)
-    history = HistoricalRecords(
-        inherit=True,
-    )
+    history = HistoricalRecords(inherit=True)
 
 
 class InheritedRestaurant(BasePlace):


### PR DESCRIPTION
Use Django's `model_to_dict` as suggested at https://github.com/treyhunner/django-simple-history/issues/575#issuecomment-514047309 to detect changes in a parent model when using `inherit=True`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/treyhunner/django-simple-history/issues/575
Related with https://github.com/treyhunner/django-simple-history/pull/479

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
