### PR TITLE
Make bulk_create_with_history working not only with PostgreSQL

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,6 +29,7 @@ Authors
 - Daniil Skrobov (`yetanotherape <https://github.com/yetanotherape>`_)
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
+- Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
 - Eduardo Cuducos
 - Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
 - Filipe Pina (@fopina)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 Unreleased
 ----------
+- Added support for bulk_create_with_history for databeses different from PostgreSQL (gh-577)
 - Fixed DoesNotExist error when trying to get instance if object is deleted (gh-571)
 
 2.7.3 (2019-07-15)

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -112,3 +112,18 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
 
         self.assertEqual(Poll.objects.count(), 0)
         self.assertEqual(Poll.history.count(), 0)
+
+    @patch("simple_history.utils.get_history_manager_for_model")
+    def test_bulk_create_no_ids_return(self, hist_manager_mock):
+        objects = [Place(id=1, name="Place 1")]
+        model = Mock(
+            objects=Mock(
+                bulk_create=Mock(return_value=[Place(name="Place 1")]),
+                filter=Mock(return_value=objects),
+            )
+        )
+        result = bulk_create_with_history(objects, model)
+        self.assertEqual(result, objects)
+        hist_manager_mock().bulk_history_create.assert_called_with(
+            objects, batch_size=None
+        )

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from django.forms.models import model_to_dict
 
 from simple_history.exceptions import NotHistoricalModelError
 
@@ -40,6 +41,9 @@ def bulk_create_with_history(objs, model, batch_size=None):
     """
     Bulk create the objects specified by objs while also bulk creating
     their history (all in one transaction).
+    Because of not providing primary key attribute after bulk_create on any DB except
+    Postgres (https://docs.djangoproject.com/en/2.2/ref/models/querysets/#bulk-create)
+    Divide this process on two transactions for other DB's
     :param objs: List of objs (not yet saved to the db) of type model
     :param model: Model class that should be created
     :param batch_size: Number of objects that should be created in each batch
@@ -47,9 +51,20 @@ def bulk_create_with_history(objs, model, batch_size=None):
     """
 
     history_manager = get_history_manager_for_model(model)
-
+    second_transaction_required = True
     with transaction.atomic(savepoint=False):
         objs_with_id = model.objects.bulk_create(objs, batch_size=batch_size)
-        history_manager.bulk_history_create(objs_with_id, batch_size=batch_size)
-
+        if objs_with_id and objs_with_id[0].pk:
+            second_transaction_required = False
+            history_manager.bulk_history_create(objs_with_id, batch_size=batch_size)
+    if second_transaction_required:
+        obj_list = []
+        with transaction.atomic(savepoint=False):
+            for obj in objs_with_id:
+                attributes = dict(
+                    filter(lambda x: x[1] is not None, model_to_dict(obj).items())
+                )
+                obj_list += model.objects.filter(**attributes)
+            history_manager.bulk_history_create(obj_list, batch_size=batch_size)
+        objs_with_id = obj_list
     return objs_with_id


### PR DESCRIPTION
Make bulk_create_with_history working not only with PostgreSQL

## Description
For AutoField only PostgreSQL returns model instances with primary keys. Other DB's keep them None. That is why the next operation create history items for these items doesn't work. 


## Related Issue
#577  

## Motivation and Context
On the local environment, developers are often using SQLite database, and bulk_create_with_history doesn't work for them.

## How Has This Been Tested?
I am already using this extended bulk_create_with_history method on production in my project.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
