### PR TITLE
Instantiate model with kwargs not args to allow for excluded fields

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -561,8 +561,8 @@ class HistoricalObjectDescriptor(object):
         self.fields_included = fields_included
 
     def __get__(self, instance, owner):
-        values = (getattr(instance, f.attname) for f in self.fields_included)
-        return self.model(*values)
+        values = {f.attname: getattr(instance, f.attname) for f in self.fields_included}
+        return self.model(**values)
 
 
 class HistoricalChanges(object):


### PR DESCRIPTION
I just installed this project to investigate an audit log feature, and I wanted to exclude one field from my model from being tracked. I did this, but then found exceptions aplenty on accessing historical records.

Digging into the code I found that the HistoricalObjectDescriptor was instantiating its model using positional args, and my excluding the first field in my model meant it was assigning values to fields shifted by one. Which might not be noticed unless types are incompatible, like mine were as a GeoDjango spatial field will error if you attempt to assign an int to it.

My quick fix was either:
1. move my excluded field to the bottom of my model :)
2. the code change in this PR

Sorry I have no time to add tests, or the package knowledge to search for similar problems to this right now, but I figured it was better to spend 5 minutes and let you know about it :)
It looks like it might solve #568 too!