### PR TITLE
update_change_reason error with excluded fields

### DIFF
--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -5,7 +5,7 @@ from mock import Mock, patch
 
 from simple_history.exceptions import NotHistoricalModelError
 from simple_history.tests.models import Document, Place, Poll, PollWithExcludeFields
-from simple_history.utils import bulk_create_with_history
+from simple_history.utils import bulk_create_with_history, update_change_reason
 
 
 class BulkCreateWithHistoryTestCase(TestCase):
@@ -112,3 +112,16 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
 
         self.assertEqual(Poll.objects.count(), 0)
         self.assertEqual(Poll.history.count(), 0)
+
+
+class UpdateChangeReasonTestCase(TestCase):
+
+    def test_update_change_reason_with_excluded_fields(self):
+        poll = PollWithExcludeFields(question="what's up?",
+                                     pub_date=now(),
+                                     place="The Pub")
+        poll.save()
+        update_change_reason(poll, 'Test change reason.')
+        most_recent = poll.history.order_by("-history_date").first()
+        self.assertEqual(most_recent.history_change_reason, 'Test change reason.')
+

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -7,7 +7,8 @@ def update_change_reason(instance, reason):
     attrs = {}
     model = type(instance)
     manager = instance if instance.id is not None else model
-    excluded_fields = getattr(model, "_history_excluded_fields", [])
+    history_model = get_history_model_for_model(instance)
+    excluded_fields = getattr(history_model, "_history_excluded_fields", [])
     for field in instance._meta.fields:
         if field.name in excluded_fields:
             continue

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -7,7 +7,10 @@ def update_change_reason(instance, reason):
     attrs = {}
     model = type(instance)
     manager = instance if instance.id is not None else model
+    excluded_fields = getattr(model, "_history_excluded_fields", [])
     for field in instance._meta.fields:
+        if field.name in excluded_fields:
+            continue
         value = getattr(instance, field.attname)
         if field.primary_key is True:
             if value is not None:


### PR DESCRIPTION
## How Has This Been Tested?
If you have excluded fields update_change_reason generates an error, The instance will have values that won't match at line 18. The change has been tested in a local project.
history.filter(**attrs)

Proposal change do avoid the error.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
