### PR TITLE
Fixed bulk_create_with_history support for relation_name attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 Unreleased
 ----------
+- Fixed bulk_create_with_history support for HistoryRecords with `relation_name` attribute (gh-591)
 - Added support for bulk_create_with_history for databeses different from PostgreSQL (gh-577)
 - Fixed DoesNotExist error when trying to get instance if object is deleted (gh-571)
 - Fix `model_to_dict` to detect changes in a parent model when using

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -101,8 +101,9 @@ class HistoryManager(models.Manager):
     def bulk_history_create(self, objs, batch_size=None):
         """Bulk create the history for the objects specified by objs"""
 
-        historical_instances = [
-            self.model(
+        historical_instances = []
+        for instance in objs:
+            row = self.model(
                 history_date=getattr(instance, "_history_date", now()),
                 history_user=getattr(instance, "_history_user", None),
                 history_change_reason=getattr(instance, "changeReason", ""),
@@ -113,8 +114,9 @@ class HistoryManager(models.Manager):
                     if field.name not in self.model._history_excluded_fields
                 }
             )
-            for instance in objs
-        ]
+            if hasattr(self.model, "history_relation"):
+                row.history_relation_id = instance.pk
+            historical_instances.append(row)
 
         return self.model.objects.bulk_create(
             historical_instances, batch_size=batch_size

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -4,7 +4,13 @@ from django.utils.timezone import now
 from mock import Mock, patch
 
 from simple_history.exceptions import NotHistoricalModelError
-from simple_history.tests.models import Document, Place, Poll, PollWithExcludeFields
+from simple_history.tests.models import (
+    Document,
+    Place,
+    Poll,
+    PollWithExcludeFields,
+    Street,
+)
 from simple_history.utils import bulk_create_with_history
 
 
@@ -62,6 +68,17 @@ class BulkCreateWithHistoryTestCase(TestCase):
 
         self.assertEqual(PollWithExcludeFields.objects.count(), 5)
         self.assertEqual(PollWithExcludeFields.history.count(), 5)
+
+    def test_bulk_create_history_with_relation_name(self):
+        self.data = [
+            Street(name="Street 1"),
+            Street(name="Street 2"),
+            Street(name="Street 3"),
+            Street(name="Street 4"),
+        ]
+        bulk_create_with_history(self.data, Street)
+        self.assertEqual(Street.objects.count(), 4)
+        self.assertEqual(Street.log.count(), 4)
 
 
 class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):


### PR DESCRIPTION
…
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bulk update with history doesn't work when HistoricalRecords has attribute `relation_name`

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/592

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
