### PR TITLE
Add an iterator to prevent OOM when cleaning large databases

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Authors
 - Brian Dixon
 - Christopher Broderick (`uhurusurfa <https://github.com/uhurusurfa>`_)
 - Corey Bertram
+- Craig Maloney (`craigmaloney <https://github.com/craigmaloney>`_)
 - Damien Nozay
 - Daniel Gilge
 - Daniel Levy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 - Fix `model_to_dict` to detect changes in a parent model when using
   `inherit=True` (backwards-incompatible for users who were directly
   using previous version) (gh-576)
+- Use an iterator for `clean_duplicate_history`
 
 2.7.3 (2019-07-15)
 ------------------

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -69,7 +69,7 @@ class Command(populate_history.Command):
             # have changes (in the given period) but
             # `m_qs.values(model._meta.pk.name).distinct()`
             # is actually slower than looping all and filtering in the code...
-            for o in model.objects..iterator():
+            for o in model.objects.iterator():
                 self._process_instance(o, model, stop_date=stop_date, dry_run=dry_run)
 
     def _process_instance(self, instance, model, stop_date=None, dry_run=True):

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -69,7 +69,7 @@ class Command(populate_history.Command):
             # have changes (in the given period) but
             # `m_qs.values(model._meta.pk.name).distinct()`
             # is actually slower than looping all and filtering in the code...
-            for o in model.objects.all().iterator():
+            for o in model.objects..iterator():
                 self._process_instance(o, model, stop_date=stop_date, dry_run=dry_run)
 
     def _process_instance(self, instance, model, stop_date=None, dry_run=True):

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -69,7 +69,7 @@ class Command(populate_history.Command):
             # have changes (in the given period) but
             # `m_qs.values(model._meta.pk.name).distinct()`
             # is actually slower than looping all and filtering in the code...
-            for o in model.objects.all():
+            for o in model.objects.all().iterator():
                 self._process_instance(o, model, stop_date=stop_date, dry_run=dry_run)
 
     def _process_instance(self, instance, model, stop_date=None, dry_run=True):

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -22,9 +22,11 @@ class AsOfTest(TestCase):
         self.obj.changed_by = user
         self.obj.save()
         self.model.objects.all().delete()  # allows us to leave PK on instance
-        self.delete_history, self.change_history, self.create_history = (
-            self.model.history.all()
-        )
+        (
+            self.delete_history,
+            self.change_history,
+            self.create_history,
+        ) = self.model.history.all()
         self.create_history.history_date = self.now - timedelta(days=2)
         self.create_history.save()
         self.change_history.history_date = self.now - timedelta(days=1)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -123,7 +123,7 @@ class HistoricalRecordsTest(TestCase):
     def test_create(self):
         p = Poll(question="what's up?", pub_date=today)
         p.save()
-        record, = p.history.all()
+        (record,) = p.history.all()
         self.assertRecordValues(
             record,
             Poll,


### PR DESCRIPTION

## Description
Adds an iterator to .all() to iterate over the data rather than load it all in memory.

## Related Issue
#603 

## Motivation and Context
Prevents loading database completely into memory.

## How Has This Been Tested?
Tested in a VM with 6GB of memory that was previously (and consistently) giving an OOM error

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
