### PR TITLE
Add setting to convert FileField to CharField instead of TextField

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -42,6 +42,7 @@ Authors
 - Guillermo Eijo (`guilleijo <https://github.com/guilleijo>`_)
 - Hamish Downer
 - Hanyin Zhang
+- Jack Cushman (`jcushman <https://github.com/jcushman>`_)
 - James Muranga (`jamesmura <https://github.com/jamesmura>`_)
 - James Pulec
 - Jesse Shapiro

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 - Add simple filtering if provided a minutes argument in `clean_duplicate_history` (gh-606)
+- Add setting to convert `FileField` to `CharField` instead of `TextField` (gh-623)
 
 2.8.0 (2019-12-02)
 ------------------

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -386,3 +386,16 @@ or the record invocation: ``app="SomeAppName"``.
     register(Opinion, app="SomeAppName")
 
 
+`FileField` as a `CharField`
+----------------------------
+
+By default a ``FileField`` in the base model becomes a ``TextField`` in the history model.
+This is a historical choice that django-simple-history preserves for backwards
+compatibility; it is more correct for a ``FileField`` to be converted to a
+``CharField`` instead. To opt into the new behavior, set the following line in your
+``settings.py`` file:
+
+.. code-block:: python
+
+    SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD = True
+

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -545,7 +545,10 @@ def transform_field(field):
 
     elif isinstance(field, models.FileField):
         # Don't copy file, just path.
-        field.__class__ = models.TextField
+        if getattr(settings, "SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD", False):
+            field.__class__ = models.CharField
+        else:
+            field.__class__ = models.TextField
 
     # Historical instance shouldn't change create/update timestamps
     field.auto_now = False

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -192,6 +192,20 @@ class FileModel(models.Model):
     history = HistoricalRecords()
 
 
+# Set SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD
+setattr(settings, "SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD", True)
+
+
+class CharFieldFileModel(models.Model):
+    title = models.CharField(max_length=100)
+    file = models.FileField(upload_to="files")
+    history = HistoricalRecords()
+
+
+# Clear SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD
+delattr(settings, "SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD")
+
+
 class Document(models.Model):
     changed_by = models.ForeignKey(
         User, on_delete=models.CASCADE, null=True, blank=True

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -42,6 +42,7 @@ from ..models import (
     BucketDataRegisterChangedBy,
     BucketMember,
     CharFieldChangeReasonModel,
+    CharFieldFileModel,
     Choice,
     City,
     ConcreteAttr,
@@ -310,6 +311,19 @@ class HistoricalRecordsTest(TestCase):
 
     def test_file_field(self):
         model = FileModel.objects.create(file=get_fake_file("name"))
+        self.assertEqual(model.file.name, "files/name")
+        model.file.delete()
+        update_record, create_record = model.history.all()
+        self.assertEqual(create_record.file, "files/name")
+        self.assertEqual(update_record.file, "")
+
+    def test_file_field_with_char_field_setting(self):
+        # setting means history table's file field is a CharField
+        file_field = CharFieldFileModel.history.model._meta.get_field("file")
+        self.assertIs(type(file_field), models.CharField)
+        self.assertEqual(file_field.max_length, 100)
+        # file field works the same as test_file_field()
+        model = CharFieldFileModel.objects.create(file=get_fake_file("name"))
         self.assertEqual(model.file.name, "files/name")
         model.file.delete()
         update_record, create_record = model.history.all()


### PR DESCRIPTION
Fix #623 by adding a `SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD` setting to convert FileFields to CharFields instead of TextFields, and related documentation.

## Description
This applies the fix suggested by @rossmechanic in #623.

Any existing project that adds the new setting will have migrations created by `./manage makemigrations` to turn the history tables from `TextField` to `CharField`.

## Related Issue
#623 

## Motivation and Context
See issue

## How Has This Been Tested?
I manually tested this by running the test suite with the branch forced to `True`, and it worked.

I don't know of a way to automatically test this one! I tried adding a `TestCase` with `@override_settings(SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD=True)`, but the setting applies too late to modify the table.

I started to seriously wonder whether it makes sense to put this behind a setting at all, given the difficulty of testing -- I think it would be correct to set to True in all cases. But the fact that it will makemigrations for existing projects does make it somewhat disruptive to change as a default.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
