### PR TITLE
import ContentType via property / django_apps.get_model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 ----------
 - Add simple filtering if provided a minutes argument in `clean_duplicate_history` (gh-606)
 - Add setting to convert `FileField` to `CharField` instead of `TextField` (gh-623)
+- import model `ContentType` in `SimpleHistoryAdmin` using `django_apps.get_model`
+  to avoid possible `AppRegistryNotReady` exception (gh-630)
 
 2.8.0 (2019-12-02)
 ------------------


### PR DESCRIPTION
## Description
I extend the `SimpleHistoryAdmin` class and depending on the loading sequence run into `AppRegistryNotReady` exception with the ContentType model class imported at the top of `SimpleHistoryAdmin`.

To fix this, I use django_apps to import the model and access it within `SimpleHistoryAdmin ` using an instance method, e.g. `content_type_model_cls()`

## How Has This Been Tested?
existing tests will cover this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
