### PR TITLE
Added possibility to specify a default user for bulk_create_with_history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@ Authors
 - Alexander Anikeev
 - Amanda Ng (`AmandaCLNg <https://github.com/AmandaCLNg>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
+- Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
 - `bradford281 <https://github.com/bradford281>`_
 - Brian Armstrong (`barm <https://github.com/barm>`_)
 - Buddy Lindsey, Jr.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Add setting to convert `FileField` to `CharField` instead of `TextField` (gh-623)
 - import model `ContentType` in `SimpleHistoryAdmin` using `django_apps.get_model`
   to avoid possible `AppRegistryNotReady` exception (gh-630)
+- Add default user to `bulk_create_with_history`
 
 2.8.0 (2019-12-02)
 ------------------

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -42,6 +42,14 @@ can add `changeReason` on each instance:
     >>> Poll.history.get(id=data[0].id).history_change_reason
     'reason'
 
+You can also specify a default user responsible for the change ( _history_user keeps precedence)
+
+.. code-block:: pycon
+
+    >>> user = User.objects.create_user("tester", "tester@example.com")
+    >>> objs = bulk_create_with_history(data, Poll, batch_size=500, default_user=user)
+    >>> Poll.history.get(id=data[0].id).history_user == user
+    True
 
 QuerySet Updates with History
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -98,14 +98,14 @@ class HistoryManager(models.Manager):
                 continue
             yield last_change.instance
 
-    def bulk_history_create(self, objs, batch_size=None):
+    def bulk_history_create(self, objs, batch_size=None, default_user=None):
         """Bulk create the history for the objects specified by objs"""
 
         historical_instances = []
         for instance in objs:
             row = self.model(
                 history_date=getattr(instance, "_history_date", now()),
-                history_user=getattr(instance, "_history_user", None),
+                history_user=getattr(instance, "_history_user", default_user),
                 history_change_reason=getattr(instance, "changeReason", ""),
                 history_type="+",
                 **{

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -126,6 +126,15 @@ class BulkHistoryCreateTestCase(TestCase):
             )
         )
 
+    def test_bulk_history_create_with_default_user(self):
+        user = User.objects.create_user("tester", "tester@example.com")
+
+        Poll.history.bulk_history_create(self.data, default_user=user)
+
+        self.assertTrue(
+            all([history.history_user == user for history in Poll.history.all()])
+        )
+
     def test_bulk_history_create_on_objs_without_ids(self):
         self.data = [
             Poll(question="Question 1", pub_date=datetime.now()),

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.test import TestCase, TransactionTestCase
 from django.utils.timezone import now
@@ -12,6 +13,8 @@ from simple_history.tests.models import (
     Street,
 )
 from simple_history.utils import bulk_create_with_history
+
+User = get_user_model()
 
 
 class BulkCreateWithHistoryTestCase(TestCase):
@@ -36,6 +39,15 @@ class BulkCreateWithHistoryTestCase(TestCase):
 
         self.assertEqual(Poll.objects.count(), 5)
         self.assertEqual(Poll.history.count(), 5)
+
+    def test_bulk_create_history_with_default_user(self):
+        user = User.objects.create_user("tester", "tester@example.com")
+
+        bulk_create_with_history(self.data, Poll, default_user=user)
+
+        self.assertTrue(
+            all([history.history_user == user for history in Poll.history.all()])
+        )
 
     def test_bulk_create_history_num_queries_is_two(self):
         with self.assertNumQueries(2):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Right now, if we want to specify a user when calling bulk_create_with_history, we have to set the user on `_history_user` for all objects. The proposed change would allow to simply specify a default user when `_history_user` is not set.

## Related Issue
Add possibility to specify a default user for bulk_create_with_history #635

## How Has This Been Tested?
I have added 2 tests:  
- one for HistoryManager.bulk_history_create
- one for bulk_create_with_history

They both pass. 3 other tests, seemingly unrelated, don't pass, but they didn't pass in master either. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
