### PR TITLE
Hotfix/update change reason with excluded fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ Authors
 - Brian Armstrong (`barm <https://github.com/barm>`_)
 - Buddy Lindsey, Jr.
 - Brian Dixon
+- Carlos San Emeterio (`Carlos-San-Emeterio <https://github.com/Carlos-San-Emeterio>`_)
 - Christopher Broderick (`uhurusurfa <https://github.com/uhurusurfa>`_)
 - Corey Bertram
 - Craig Maloney (`craigmaloney <https://github.com/craigmaloney>`_)
@@ -52,6 +53,7 @@ Authors
 - `jofusa <https://github.com/jofusa>`_
 - John Whitlock
 - Jonathan Leroy
+- Jonathan Loo (`alpha1d3d <https://github.com/alpha1d3d>`_)
 - Jonathan Sanchez
 - Jonathan Zvesper (`zvesp <https://github.com/zvesp>`_)
 - Josh Fyne

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Add setting to convert `FileField` to `CharField` instead of `TextField` (gh-623)
 - import model `ContentType` in `SimpleHistoryAdmin` using `django_apps.get_model`
   to avoid possible `AppRegistryNotReady` exception (gh-630)
+- Fix `utils.update_change_reason` when user specifies excluded_fields
 
 2.8.0 (2019-12-02)
 ------------------

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -147,12 +147,11 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
 
 
 class UpdateChangeReasonTestCase(TestCase):
-
     def test_update_change_reason_with_excluded_fields(self):
-        poll = PollWithExcludeFields(question="what's up?",
-                                     pub_date=now(),
-                                     place="The Pub")
+        poll = PollWithExcludeFields(
+            question="what's up?", pub_date=now(), place="The Pub"
+        )
         poll.save()
-        update_change_reason(poll, 'Test change reason.')
+        update_change_reason(poll, "Test change reason.")
         most_recent = poll.history.order_by("-history_date").first()
-        self.assertEqual(most_recent.history_change_reason, 'Test change reason.')
+        self.assertEqual(most_recent.history_change_reason, "Test change reason.")

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -11,7 +11,7 @@ from simple_history.tests.models import (
     PollWithExcludeFields,
     Street,
 )
-from simple_history.utils import bulk_create_with_history
+from simple_history.utils import bulk_create_with_history, update_change_reason
 
 
 class BulkCreateWithHistoryTestCase(TestCase):
@@ -144,3 +144,15 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         hist_manager_mock().bulk_history_create.assert_called_with(
             objects, batch_size=None
         )
+
+
+class UpdateChangeReasonTestCase(TestCase):
+
+    def test_update_change_reason_with_excluded_fields(self):
+        poll = PollWithExcludeFields(question="what's up?",
+                                     pub_date=now(),
+                                     place="The Pub")
+        poll.save()
+        update_change_reason(poll, 'Test change reason.')
+        most_recent = poll.history.order_by("-history_date").first()
+        self.assertEqual(most_recent.history_change_reason, 'Test change reason.')

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -8,7 +8,8 @@ def update_change_reason(instance, reason):
     attrs = {}
     model = type(instance)
     manager = instance if instance.id is not None else model
-    excluded_fields = getattr(model, "_history_excluded_fields", [])
+    history_model = get_history_model_for_model(instance)
+    excluded_fields = getattr(history_model, "_history_excluded_fields", [])
     for field in instance._meta.fields:
         if field.name in excluded_fields:
             continue

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -8,7 +8,10 @@ def update_change_reason(instance, reason):
     attrs = {}
     model = type(instance)
     manager = instance if instance.id is not None else model
+    excluded_fields = getattr(model, "_history_excluded_fields", [])
     for field in instance._meta.fields:
+        if field.name in excluded_fields:
+            continue
         value = getattr(instance, field.attname)
         if field.primary_key is True:
             if value is not None:

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -8,10 +8,10 @@ def update_change_reason(instance, reason):
     attrs = {}
     model = type(instance)
     manager = instance if instance.id is not None else model
-    history_model = get_history_model_for_model(instance)
-    excluded_fields = getattr(history_model, "_history_excluded_fields", [])
+    history = get_history_manager_for_model(manager)
+    history_fields = [field.attname for field in history.model._meta.fields]
     for field in instance._meta.fields:
-        if field.name in excluded_fields:
+        if field.attname not in history_fields:
             continue
         value = getattr(instance, field.attname)
         if field.primary_key is True:
@@ -19,7 +19,7 @@ def update_change_reason(instance, reason):
                 attrs[field.attname] = value
         else:
             attrs[field.attname] = value
-    history = get_history_manager_for_model(manager)
+
     record = history.filter(**attrs).order_by("-history_date").first()
     record.history_change_reason = reason
     record.save()


### PR DESCRIPTION
## Description
PR based on @Carlos-San-Emeterio 's work https://github.com/treyhunner/django-simple-history/pull/588, which has not been updated in months and the issue is still present.

## Related Issue
PR: https://github.com/treyhunner/django-simple-history/pull/588

## Motivation and Context
Original PR had conflicts and no response from creator for 6 months. 
Also updated with some minor fix.

## How Has This Been Tested?
From original PR:

> If you have excluded fields update_change_reason generates an error, The instance will have values that won't match at line 18. The change has been tested in a local project.
> history.filter(**attrs)
> 
> Proposal change do avoid the error.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
