### PR TITLE
Changed timezone.now import to `from django.utils import timezone`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,6 +43,7 @@ Authors
 - Guillermo Eijo (`guilleijo <https://github.com/guilleijo>`_)
 - Hamish Downer
 - Hanyin Zhang
+- Hernan Esteves (`sevetseh28 <https://github.com/sevetseh28>`_)
 - Jack Cushman (`jcushman <https://github.com/jcushman>`_)
 - James Muranga (`jamesmura <https://github.com/jamesmura>`_)
 - James Pulec

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 Unreleased
 ----------
+- Changed how `now` is imported from `timezone` (`timezone` module is imported now)
 - Add simple filtering if provided a minutes argument in `clean_duplicate_history` (gh-606)
 - Add setting to convert `FileField` to `CharField` instead of `TextField` (gh-623)
 - import model `ContentType` in `SimpleHistoryAdmin` using `django_apps.get_model`

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.timezone import now
+from django.utils import timezone
 
 
 class HistoryDescriptor(object):
@@ -104,7 +104,7 @@ class HistoryManager(models.Manager):
         historical_instances = []
         for instance in objs:
             row = self.model(
-                history_date=getattr(instance, "_history_date", now()),
+                history_date=getattr(instance, "_history_date", timezone.now()),
                 history_user=getattr(instance, "_history_user", None),
                 history_change_reason=getattr(instance, "changeReason", ""),
                 history_type="+",

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -19,7 +19,7 @@ from django.db.models.fields.proxy import OrderWrt
 from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils.text import format_lazy
-from django.utils.timezone import now
+from django.utils import timezone
 from simple_history import utils
 from . import exceptions
 from .manager import HistoryDescriptor
@@ -477,7 +477,7 @@ class HistoricalRecords(object):
 
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None
-        history_date = getattr(instance, "_history_date", now())
+        history_date = getattr(instance, "_history_date", timezone.now())
         history_user = self.get_history_user(instance)
         history_change_reason = getattr(instance, "changeReason", None)
         manager = getattr(instance, self.manager_name)

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -1,6 +1,6 @@
 from django.db import IntegrityError
 from django.test import TestCase, TransactionTestCase
-from django.utils.timezone import now
+from django.utils import timezone
 from mock import Mock, patch
 
 from simple_history.exceptions import NotHistoricalModelError
@@ -17,18 +17,18 @@ from simple_history.utils import bulk_create_with_history, update_change_reason
 class BulkCreateWithHistoryTestCase(TestCase):
     def setUp(self):
         self.data = [
-            Poll(id=1, question="Question 1", pub_date=now()),
-            Poll(id=2, question="Question 2", pub_date=now()),
-            Poll(id=3, question="Question 3", pub_date=now()),
-            Poll(id=4, question="Question 4", pub_date=now()),
-            Poll(id=5, question="Question 5", pub_date=now()),
+            Poll(id=1, question="Question 1", pub_date=timezone.now()),
+            Poll(id=2, question="Question 2", pub_date=timezone.now()),
+            Poll(id=3, question="Question 3", pub_date=timezone.now()),
+            Poll(id=4, question="Question 4", pub_date=timezone.now()),
+            Poll(id=5, question="Question 5", pub_date=timezone.now()),
         ]
         self.data_with_excluded_fields = [
-            PollWithExcludeFields(id=1, question="Question 1", pub_date=now()),
-            PollWithExcludeFields(id=2, question="Question 2", pub_date=now()),
-            PollWithExcludeFields(id=3, question="Question 3", pub_date=now()),
-            PollWithExcludeFields(id=4, question="Question 4", pub_date=now()),
-            PollWithExcludeFields(id=5, question="Question 5", pub_date=now()),
+            PollWithExcludeFields(id=1, question="Question 1", pub_date=timezone.now()),
+            PollWithExcludeFields(id=2, question="Question 2", pub_date=timezone.now()),
+            PollWithExcludeFields(id=3, question="Question 3", pub_date=timezone.now()),
+            PollWithExcludeFields(id=4, question="Question 4", pub_date=timezone.now()),
+            PollWithExcludeFields(id=5, question="Question 5", pub_date=timezone.now()),
         ]
 
     def test_bulk_create_history(self):
@@ -84,11 +84,11 @@ class BulkCreateWithHistoryTestCase(TestCase):
 class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
     def setUp(self):
         self.data = [
-            Poll(id=1, question="Question 1", pub_date=now()),
-            Poll(id=2, question="Question 2", pub_date=now()),
-            Poll(id=3, question="Question 3", pub_date=now()),
-            Poll(id=4, question="Question 4", pub_date=now()),
-            Poll(id=5, question="Question 5", pub_date=now()),
+            Poll(id=1, question="Question 1", pub_date=timezone.now()),
+            Poll(id=2, question="Question 2", pub_date=timezone.now()),
+            Poll(id=3, question="Question 3", pub_date=timezone.now()),
+            Poll(id=4, question="Question 4", pub_date=timezone.now()),
+            Poll(id=5, question="Question 5", pub_date=timezone.now()),
         ]
 
     @patch(
@@ -112,7 +112,7 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         self.assertEqual(Poll.history.count(), 0)
 
     def test_bulk_create_history_rolls_back_when_last_exists(self):
-        Poll.objects.create(id=5, question="Question 5", pub_date=now())
+        Poll.objects.create(id=5, question="Question 5", pub_date=timezone.now())
 
         self.assertEqual(Poll.objects.count(), 1)
         self.assertEqual(Poll.history.count(), 1)
@@ -149,7 +149,7 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
 class UpdateChangeReasonTestCase(TestCase):
     def test_update_change_reason_with_excluded_fields(self):
         poll = PollWithExcludeFields(
-            question="what's up?", pub_date=now(), place="The Pub"
+            question="what's up?", pub_date=timezone.now(), place="The Pub"
         )
         poll.save()
         update_change_reason(poll, "Test change reason.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I changed the way the `now` function from django is imported and executed following the Django standard of using it: https://docs.djangoproject.com/en/3.0/topics/i18n/timezones/

If you have tests that mock `django.utils.timezone.now` it will also work now, so you don't have to patch twice. Besides, it is clearer to specify the timezone module, since `now` is found in many modules.

## Description
<!--- Describe your changes in detail -->
It's a very simple PR, the summary has all details.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
