### PR TITLE
Revert GH-641

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -82,7 +82,6 @@ Authors
 - Prakash Venkatraman (`dopatraman <https://github.com/dopatraman>`_)
 - Rajesh Pappula
 - Ray Logel
-- Reza Pourmeshki (`partizaans <https://github.com/partizaans>`_)
 - Roberto Aguilar
 - Rod Xavier Bondoc
 - Ross Lote

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,6 @@ Changes
   to avoid possible `AppRegistryNotReady` exception (gh-630)
 - Fix `utils.update_change_reason` when user specifies excluded_fields (gh-637)
 - Changed how `now` is imported from `timezone` (`timezone` module is imported now) (gh-643)
-- Render fields as readonly in history detail view if `SIMPLE_HISTORY_EDIT` is not set
-  `True` (gh-641)
 - settings.SIMPLE_HISTORY_REVERT_DISABLED if True removes the Revert
   button from the history form for all historical models (gh-632))
 

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -175,9 +175,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             form,
             self.get_fieldsets(request, obj),
             self.prepopulated_fields,
-            self.get_readonly_fields(request, obj)
-            if change_history
-            else self.get_fields(request, obj),
+            self.get_readonly_fields(request, obj),
             model_admin=self,
         )
 

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -154,8 +154,7 @@ class AdminSiteTest(TestCase):
     def test_invalid_history_form(self):
         self.login()
         poll = Poll.objects.create(question="why?", pub_date=today)
-        with patch("simple_history.admin.SIMPLE_HISTORY_EDIT", True):
-            response = self.client.post(get_history_url(poll, 0), data={"question": ""})
+        response = self.client.post(get_history_url(poll, 0), data={"question": ""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "This field is required")
 
@@ -200,25 +199,6 @@ class AdminSiteTest(TestCase):
         self.assertEqual(
             [p.history_user for p in Poll.history.all()], [self.user, None, None]
         )
-
-    def test_readonly_history_form_without_setting_simple_history_edit(self):
-        self.login()
-        poll = Poll.objects.create(question="why?", pub_date=today)
-        poll.question = "how?"
-        poll.save()
-        response = self.client.get(get_history_url(poll, 0))
-        readonly_fields = response.context["adminform"].readonly_fields
-        self.assertCountEqual(["question", "pub_date"], readonly_fields)
-
-    def test_readonly_history_form_with_enabled_simple_history_edit(self):
-        self.login()
-        poll = Poll.objects.create(question="why?", pub_date=today)
-        poll.question = "how?"
-        poll.save()
-        with patch("simple_history.admin.SIMPLE_HISTORY_EDIT", True):
-            response = self.client.get(get_history_url(poll, 0))
-        readonly_fields = response.context["adminform"].readonly_fields
-        self.assertEqual(0, len(readonly_fields))
 
     def test_history_user_on_save_in_admin(self):
         self.login()


### PR DESCRIPTION
#641 does not work. The revert currently relies on fields passed into the form, and when we specify. The AdminForm doesn't treat `readonly` fields as inputs, and thus fails validation. There's definitely reasonable solution here, but going to revert for now so I can release.