### PR TITLE
Remove invalid reference in docs

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -104,7 +104,6 @@ Tracking Custom Users
 
     Use ``register()`` to track changes to the custom user model
     instead of setting ``HistoricalRecords`` on the model directly.
-    See :ref:`register`.
 
     The reason for this, is that unfortunately ``HistoricalRecords``
     cannot be set directly on a swapped user model because of the user

--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -122,9 +122,6 @@ model history.
     <Poll: Poll object as of 2010-10-25 18:04:13.814128>
 
 
-.. _register:
-
-
 Save without a historical record
 --------------------------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`register` reference resolves to `Save without a historical record` which doesn't make sense. The reference looks to be leftover from past doc reorganizations. 

As there is no section which actually provides great content about `register`, better to just remove the reference completely, instead of causing confusion.

## Checklist:
- [ ] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.

